### PR TITLE
Update api version to v0.4.0

### DIFF
--- a/cloudclient/options.go
+++ b/cloudclient/options.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	defaultCloudOpsAPIHostPort = "saas-api.tmprl.cloud:443"
-	defaultAPIVersion          = "v0.3.0"
+	defaultAPIVersion          = "v0.4.0"
 
 	authorizationHeader           = "Authorization"
 	authorizationBearer           = "Bearer"


### PR DESCRIPTION
## What was changed
Start using `v0.4.0` api version.