### PR TITLE
Bump cloud-api to v0.17.0

### DIFF
--- a/api/cloudservice/v1/request_response.pb.go
+++ b/api/cloudservice/v1/request_response.pb.go
@@ -8051,6 +8051,360 @@ func (x *DeleteCustomRoleResponse) GetAsyncOperation() *v11.AsyncOperation {
 	return nil
 }
 
+type GetUserNamespaceAssignmentsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The namespace to get users for.
+	Namespace string `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	// The requested size of the page to retrieve - optional.
+	// Cannot exceed 1000. Defaults to 100.
+	PageSize int32 `protobuf:"varint,2,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// The page token if this is continuing from another response - optional.
+	PageToken     string `protobuf:"bytes,3,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetUserNamespaceAssignmentsRequest) Reset() {
+	*x = GetUserNamespaceAssignmentsRequest{}
+	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[146]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetUserNamespaceAssignmentsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetUserNamespaceAssignmentsRequest) ProtoMessage() {}
+
+func (x *GetUserNamespaceAssignmentsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[146]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetUserNamespaceAssignmentsRequest.ProtoReflect.Descriptor instead.
+func (*GetUserNamespaceAssignmentsRequest) Descriptor() ([]byte, []int) {
+	return file_temporal_api_cloud_cloudservice_v1_request_response_proto_rawDescGZIP(), []int{146}
+}
+
+func (x *GetUserNamespaceAssignmentsRequest) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *GetUserNamespaceAssignmentsRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *GetUserNamespaceAssignmentsRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+type GetUserNamespaceAssignmentsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The list of users with access to the namespace.
+	Users []*v1.UserNamespaceAssignment `protobuf:"bytes,1,rep,name=users,proto3" json:"users,omitempty"`
+	// The next page's token.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetUserNamespaceAssignmentsResponse) Reset() {
+	*x = GetUserNamespaceAssignmentsResponse{}
+	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[147]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetUserNamespaceAssignmentsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetUserNamespaceAssignmentsResponse) ProtoMessage() {}
+
+func (x *GetUserNamespaceAssignmentsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[147]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetUserNamespaceAssignmentsResponse.ProtoReflect.Descriptor instead.
+func (*GetUserNamespaceAssignmentsResponse) Descriptor() ([]byte, []int) {
+	return file_temporal_api_cloud_cloudservice_v1_request_response_proto_rawDescGZIP(), []int{147}
+}
+
+func (x *GetUserNamespaceAssignmentsResponse) GetUsers() []*v1.UserNamespaceAssignment {
+	if x != nil {
+		return x.Users
+	}
+	return nil
+}
+
+func (x *GetUserNamespaceAssignmentsResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
+type GetServiceAccountNamespaceAssignmentsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The namespace to get service accounts for.
+	Namespace string `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	// The requested size of the page to retrieve - optional.
+	// Cannot exceed 1000. Defaults to 100.
+	PageSize int32 `protobuf:"varint,2,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// The page token if this is continuing from another response - optional.
+	PageToken     string `protobuf:"bytes,3,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetServiceAccountNamespaceAssignmentsRequest) Reset() {
+	*x = GetServiceAccountNamespaceAssignmentsRequest{}
+	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[148]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetServiceAccountNamespaceAssignmentsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetServiceAccountNamespaceAssignmentsRequest) ProtoMessage() {}
+
+func (x *GetServiceAccountNamespaceAssignmentsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[148]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetServiceAccountNamespaceAssignmentsRequest.ProtoReflect.Descriptor instead.
+func (*GetServiceAccountNamespaceAssignmentsRequest) Descriptor() ([]byte, []int) {
+	return file_temporal_api_cloud_cloudservice_v1_request_response_proto_rawDescGZIP(), []int{148}
+}
+
+func (x *GetServiceAccountNamespaceAssignmentsRequest) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *GetServiceAccountNamespaceAssignmentsRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *GetServiceAccountNamespaceAssignmentsRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+type GetServiceAccountNamespaceAssignmentsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The list of service accounts with access to the namespace.
+	ServiceAccounts []*v1.ServiceAccountNamespaceAssignment `protobuf:"bytes,1,rep,name=service_accounts,json=serviceAccounts,proto3" json:"service_accounts,omitempty"`
+	// The next page's token.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetServiceAccountNamespaceAssignmentsResponse) Reset() {
+	*x = GetServiceAccountNamespaceAssignmentsResponse{}
+	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[149]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetServiceAccountNamespaceAssignmentsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetServiceAccountNamespaceAssignmentsResponse) ProtoMessage() {}
+
+func (x *GetServiceAccountNamespaceAssignmentsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[149]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetServiceAccountNamespaceAssignmentsResponse.ProtoReflect.Descriptor instead.
+func (*GetServiceAccountNamespaceAssignmentsResponse) Descriptor() ([]byte, []int) {
+	return file_temporal_api_cloud_cloudservice_v1_request_response_proto_rawDescGZIP(), []int{149}
+}
+
+func (x *GetServiceAccountNamespaceAssignmentsResponse) GetServiceAccounts() []*v1.ServiceAccountNamespaceAssignment {
+	if x != nil {
+		return x.ServiceAccounts
+	}
+	return nil
+}
+
+func (x *GetServiceAccountNamespaceAssignmentsResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
+type GetUserGroupNamespaceAssignmentsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The namespace to get user groups for.
+	Namespace string `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	// The requested size of the page to retrieve - optional.
+	// Cannot exceed 1000. Defaults to 100.
+	PageSize int32 `protobuf:"varint,2,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// The page token if this is continuing from another response - optional.
+	PageToken     string `protobuf:"bytes,3,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetUserGroupNamespaceAssignmentsRequest) Reset() {
+	*x = GetUserGroupNamespaceAssignmentsRequest{}
+	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[150]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetUserGroupNamespaceAssignmentsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetUserGroupNamespaceAssignmentsRequest) ProtoMessage() {}
+
+func (x *GetUserGroupNamespaceAssignmentsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[150]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetUserGroupNamespaceAssignmentsRequest.ProtoReflect.Descriptor instead.
+func (*GetUserGroupNamespaceAssignmentsRequest) Descriptor() ([]byte, []int) {
+	return file_temporal_api_cloud_cloudservice_v1_request_response_proto_rawDescGZIP(), []int{150}
+}
+
+func (x *GetUserGroupNamespaceAssignmentsRequest) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *GetUserGroupNamespaceAssignmentsRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *GetUserGroupNamespaceAssignmentsRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+type GetUserGroupNamespaceAssignmentsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The list of user groups with access to the namespace.
+	Groups []*v1.UserGroupNamespaceAssignment `protobuf:"bytes,1,rep,name=groups,proto3" json:"groups,omitempty"`
+	// The next page's token.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetUserGroupNamespaceAssignmentsResponse) Reset() {
+	*x = GetUserGroupNamespaceAssignmentsResponse{}
+	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[151]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetUserGroupNamespaceAssignmentsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetUserGroupNamespaceAssignmentsResponse) ProtoMessage() {}
+
+func (x *GetUserGroupNamespaceAssignmentsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[151]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetUserGroupNamespaceAssignmentsResponse.ProtoReflect.Descriptor instead.
+func (*GetUserGroupNamespaceAssignmentsResponse) Descriptor() ([]byte, []int) {
+	return file_temporal_api_cloud_cloudservice_v1_request_response_proto_rawDescGZIP(), []int{151}
+}
+
+func (x *GetUserGroupNamespaceAssignmentsResponse) GetGroups() []*v1.UserGroupNamespaceAssignment {
+	if x != nil {
+		return x.Groups
+	}
+	return nil
+}
+
+func (x *GetUserGroupNamespaceAssignmentsResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
 type GetUserGroupsRequest_GoogleGroupFilter struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Filter groups by the google group email - optional.
@@ -8061,7 +8415,7 @@ type GetUserGroupsRequest_GoogleGroupFilter struct {
 
 func (x *GetUserGroupsRequest_GoogleGroupFilter) Reset() {
 	*x = GetUserGroupsRequest_GoogleGroupFilter{}
-	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[147]
+	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[153]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8073,7 +8427,7 @@ func (x *GetUserGroupsRequest_GoogleGroupFilter) String() string {
 func (*GetUserGroupsRequest_GoogleGroupFilter) ProtoMessage() {}
 
 func (x *GetUserGroupsRequest_GoogleGroupFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[147]
+	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[153]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8106,7 +8460,7 @@ type GetUserGroupsRequest_SCIMGroupFilter struct {
 
 func (x *GetUserGroupsRequest_SCIMGroupFilter) Reset() {
 	*x = GetUserGroupsRequest_SCIMGroupFilter{}
-	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[148]
+	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[154]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8118,7 +8472,7 @@ func (x *GetUserGroupsRequest_SCIMGroupFilter) String() string {
 func (*GetUserGroupsRequest_SCIMGroupFilter) ProtoMessage() {}
 
 func (x *GetUserGroupsRequest_SCIMGroupFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[148]
+	mi := &file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes[154]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9440,20 +9794,78 @@ var file_temporal_api_cloud_cloudservice_v1_request_response_proto_rawDesc = str
 	0x61, 0x70, 0x69, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2e, 0x6f, 0x70, 0x65, 0x72, 0x61, 0x74,
 	0x69, 0x6f, 0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x73, 0x79, 0x6e, 0x63, 0x4f, 0x70, 0x65, 0x72,
 	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x0e, 0x61, 0x73, 0x79, 0x6e, 0x63, 0x4f, 0x70, 0x65, 0x72,
-	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0xc8, 0x01, 0x0a, 0x25, 0x69, 0x6f, 0x2e, 0x74, 0x65, 0x6d,
+	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x7e, 0x0a, 0x22, 0x47, 0x65, 0x74, 0x55, 0x73, 0x65, 0x72,
+	0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x73, 0x73, 0x69, 0x67, 0x6e, 0x6d,
+	0x65, 0x6e, 0x74, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x1c, 0x0a, 0x09, 0x6e,
+	0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09,
+	0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x12, 0x1b, 0x0a, 0x09, 0x70, 0x61, 0x67,
+	0x65, 0x5f, 0x73, 0x69, 0x7a, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x08, 0x70, 0x61,
+	0x67, 0x65, 0x53, 0x69, 0x7a, 0x65, 0x12, 0x1d, 0x0a, 0x0a, 0x70, 0x61, 0x67, 0x65, 0x5f, 0x74,
+	0x6f, 0x6b, 0x65, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x70, 0x61, 0x67, 0x65,
+	0x54, 0x6f, 0x6b, 0x65, 0x6e, 0x22, 0x9c, 0x01, 0x0a, 0x23, 0x47, 0x65, 0x74, 0x55, 0x73, 0x65,
+	0x72, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x73, 0x73, 0x69, 0x67, 0x6e,
+	0x6d, 0x65, 0x6e, 0x74, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x4d, 0x0a,
+	0x05, 0x75, 0x73, 0x65, 0x72, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x37, 0x2e, 0x74,
+	0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x63, 0x6c, 0x6f, 0x75,
+	0x64, 0x2e, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x2e, 0x76, 0x31, 0x2e, 0x55, 0x73,
+	0x65, 0x72, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x73, 0x73, 0x69, 0x67,
+	0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x52, 0x05, 0x75, 0x73, 0x65, 0x72, 0x73, 0x12, 0x26, 0x0a, 0x0f,
+	0x6e, 0x65, 0x78, 0x74, 0x5f, 0x70, 0x61, 0x67, 0x65, 0x5f, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x18,
+	0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0d, 0x6e, 0x65, 0x78, 0x74, 0x50, 0x61, 0x67, 0x65, 0x54,
+	0x6f, 0x6b, 0x65, 0x6e, 0x22, 0x88, 0x01, 0x0a, 0x2c, 0x47, 0x65, 0x74, 0x53, 0x65, 0x72, 0x76,
+	0x69, 0x63, 0x65, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70,
+	0x61, 0x63, 0x65, 0x41, 0x73, 0x73, 0x69, 0x67, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x52, 0x65,
+	0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x1c, 0x0a, 0x09, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61,
+	0x63, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70,
+	0x61, 0x63, 0x65, 0x12, 0x1b, 0x0a, 0x09, 0x70, 0x61, 0x67, 0x65, 0x5f, 0x73, 0x69, 0x7a, 0x65,
+	0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x08, 0x70, 0x61, 0x67, 0x65, 0x53, 0x69, 0x7a, 0x65,
+	0x12, 0x1d, 0x0a, 0x0a, 0x70, 0x61, 0x67, 0x65, 0x5f, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x18, 0x03,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x70, 0x61, 0x67, 0x65, 0x54, 0x6f, 0x6b, 0x65, 0x6e, 0x22,
+	0xc5, 0x01, 0x0a, 0x2d, 0x47, 0x65, 0x74, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x41, 0x63,
+	0x63, 0x6f, 0x75, 0x6e, 0x74, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x73,
+	0x73, 0x69, 0x67, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73,
+	0x65, 0x12, 0x6c, 0x0a, 0x10, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x5f, 0x61, 0x63, 0x63,
+	0x6f, 0x75, 0x6e, 0x74, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x41, 0x2e, 0x74, 0x65,
+	0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64,
+	0x2e, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x2e, 0x76, 0x31, 0x2e, 0x53, 0x65, 0x72,
+	0x76, 0x69, 0x63, 0x65, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x4e, 0x61, 0x6d, 0x65, 0x73,
+	0x70, 0x61, 0x63, 0x65, 0x41, 0x73, 0x73, 0x69, 0x67, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x52, 0x0f,
+	0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x12,
+	0x26, 0x0a, 0x0f, 0x6e, 0x65, 0x78, 0x74, 0x5f, 0x70, 0x61, 0x67, 0x65, 0x5f, 0x74, 0x6f, 0x6b,
+	0x65, 0x6e, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0d, 0x6e, 0x65, 0x78, 0x74, 0x50, 0x61,
+	0x67, 0x65, 0x54, 0x6f, 0x6b, 0x65, 0x6e, 0x22, 0x83, 0x01, 0x0a, 0x27, 0x47, 0x65, 0x74, 0x55,
+	0x73, 0x65, 0x72, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63,
+	0x65, 0x41, 0x73, 0x73, 0x69, 0x67, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x52, 0x65, 0x71, 0x75,
+	0x65, 0x73, 0x74, 0x12, 0x1c, 0x0a, 0x09, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65,
+	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63,
+	0x65, 0x12, 0x1b, 0x0a, 0x09, 0x70, 0x61, 0x67, 0x65, 0x5f, 0x73, 0x69, 0x7a, 0x65, 0x18, 0x02,
+	0x20, 0x01, 0x28, 0x05, 0x52, 0x08, 0x70, 0x61, 0x67, 0x65, 0x53, 0x69, 0x7a, 0x65, 0x12, 0x1d,
+	0x0a, 0x0a, 0x70, 0x61, 0x67, 0x65, 0x5f, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x18, 0x03, 0x20, 0x01,
+	0x28, 0x09, 0x52, 0x09, 0x70, 0x61, 0x67, 0x65, 0x54, 0x6f, 0x6b, 0x65, 0x6e, 0x22, 0xa8, 0x01,
+	0x0a, 0x28, 0x47, 0x65, 0x74, 0x55, 0x73, 0x65, 0x72, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x4e, 0x61,
+	0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x73, 0x73, 0x69, 0x67, 0x6e, 0x6d, 0x65, 0x6e,
+	0x74, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x54, 0x0a, 0x06, 0x67, 0x72,
+	0x6f, 0x75, 0x70, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x3c, 0x2e, 0x74, 0x65, 0x6d,
 	0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2e,
-	0x63, 0x6c, 0x6f, 0x75, 0x64, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e, 0x76, 0x31, 0x42,
-	0x14, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65,
-	0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x35, 0x67, 0x6f, 0x2e, 0x74, 0x65, 0x6d, 0x70,
-	0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x69, 0x6f, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x63, 0x6c, 0x6f, 0x75,
-	0x64, 0x2f, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2f, 0x76,
-	0x31, 0x3b, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0xaa, 0x02,
-	0x24, 0x54, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x69, 0x6f, 0x2e, 0x41, 0x70, 0x69, 0x2e,
-	0x43, 0x6c, 0x6f, 0x75, 0x64, 0x2e, 0x43, 0x6c, 0x6f, 0x75, 0x64, 0x53, 0x65, 0x72, 0x76, 0x69,
-	0x63, 0x65, 0x2e, 0x56, 0x31, 0xea, 0x02, 0x28, 0x54, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c,
-	0x69, 0x6f, 0x3a, 0x3a, 0x41, 0x70, 0x69, 0x3a, 0x3a, 0x43, 0x6c, 0x6f, 0x75, 0x64, 0x3a, 0x3a,
-	0x43, 0x6c, 0x6f, 0x75, 0x64, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x3a, 0x3a, 0x56, 0x31,
-	0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x2e, 0x76, 0x31, 0x2e, 0x55, 0x73, 0x65, 0x72,
+	0x47, 0x72, 0x6f, 0x75, 0x70, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x73,
+	0x73, 0x69, 0x67, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x52, 0x06, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x73,
+	0x12, 0x26, 0x0a, 0x0f, 0x6e, 0x65, 0x78, 0x74, 0x5f, 0x70, 0x61, 0x67, 0x65, 0x5f, 0x74, 0x6f,
+	0x6b, 0x65, 0x6e, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0d, 0x6e, 0x65, 0x78, 0x74, 0x50,
+	0x61, 0x67, 0x65, 0x54, 0x6f, 0x6b, 0x65, 0x6e, 0x42, 0xc8, 0x01, 0x0a, 0x25, 0x69, 0x6f, 0x2e,
+	0x74, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x63, 0x6c, 0x6f,
+	0x75, 0x64, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e,
+	0x76, 0x31, 0x42, 0x14, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x52, 0x65, 0x73, 0x70, 0x6f,
+	0x6e, 0x73, 0x65, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x35, 0x67, 0x6f, 0x2e, 0x74,
+	0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x69, 0x6f, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x63,
+	0x6c, 0x6f, 0x75, 0x64, 0x2f, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63,
+	0x65, 0x2f, 0x76, 0x31, 0x3b, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63,
+	0x65, 0xaa, 0x02, 0x24, 0x54, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x69, 0x6f, 0x2e, 0x41,
+	0x70, 0x69, 0x2e, 0x43, 0x6c, 0x6f, 0x75, 0x64, 0x2e, 0x43, 0x6c, 0x6f, 0x75, 0x64, 0x53, 0x65,
+	0x72, 0x76, 0x69, 0x63, 0x65, 0x2e, 0x56, 0x31, 0xea, 0x02, 0x28, 0x54, 0x65, 0x6d, 0x70, 0x6f,
+	0x72, 0x61, 0x6c, 0x69, 0x6f, 0x3a, 0x3a, 0x41, 0x70, 0x69, 0x3a, 0x3a, 0x43, 0x6c, 0x6f, 0x75,
+	0x64, 0x3a, 0x3a, 0x43, 0x6c, 0x6f, 0x75, 0x64, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x3a,
+	0x3a, 0x56, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 })
 
 var (
@@ -9468,309 +9880,321 @@ func file_temporal_api_cloud_cloudservice_v1_request_response_proto_rawDescGZIP(
 	return file_temporal_api_cloud_cloudservice_v1_request_response_proto_rawDescData
 }
 
-var file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes = make([]protoimpl.MessageInfo, 150)
+var file_temporal_api_cloud_cloudservice_v1_request_response_proto_msgTypes = make([]protoimpl.MessageInfo, 156)
 var file_temporal_api_cloud_cloudservice_v1_request_response_proto_goTypes = []any{
-	(*GetCurrentIdentityRequest)(nil),                // 0: temporal.api.cloud.cloudservice.v1.GetCurrentIdentityRequest
-	(*GetCurrentIdentityResponse)(nil),               // 1: temporal.api.cloud.cloudservice.v1.GetCurrentIdentityResponse
-	(*GetUsersRequest)(nil),                          // 2: temporal.api.cloud.cloudservice.v1.GetUsersRequest
-	(*GetUsersResponse)(nil),                         // 3: temporal.api.cloud.cloudservice.v1.GetUsersResponse
-	(*GetUserRequest)(nil),                           // 4: temporal.api.cloud.cloudservice.v1.GetUserRequest
-	(*GetUserResponse)(nil),                          // 5: temporal.api.cloud.cloudservice.v1.GetUserResponse
-	(*CreateUserRequest)(nil),                        // 6: temporal.api.cloud.cloudservice.v1.CreateUserRequest
-	(*CreateUserResponse)(nil),                       // 7: temporal.api.cloud.cloudservice.v1.CreateUserResponse
-	(*UpdateUserRequest)(nil),                        // 8: temporal.api.cloud.cloudservice.v1.UpdateUserRequest
-	(*UpdateUserResponse)(nil),                       // 9: temporal.api.cloud.cloudservice.v1.UpdateUserResponse
-	(*DeleteUserRequest)(nil),                        // 10: temporal.api.cloud.cloudservice.v1.DeleteUserRequest
-	(*DeleteUserResponse)(nil),                       // 11: temporal.api.cloud.cloudservice.v1.DeleteUserResponse
-	(*SetUserNamespaceAccessRequest)(nil),            // 12: temporal.api.cloud.cloudservice.v1.SetUserNamespaceAccessRequest
-	(*SetUserNamespaceAccessResponse)(nil),           // 13: temporal.api.cloud.cloudservice.v1.SetUserNamespaceAccessResponse
-	(*GetAsyncOperationRequest)(nil),                 // 14: temporal.api.cloud.cloudservice.v1.GetAsyncOperationRequest
-	(*GetAsyncOperationResponse)(nil),                // 15: temporal.api.cloud.cloudservice.v1.GetAsyncOperationResponse
-	(*CreateNamespaceRequest)(nil),                   // 16: temporal.api.cloud.cloudservice.v1.CreateNamespaceRequest
-	(*CreateNamespaceResponse)(nil),                  // 17: temporal.api.cloud.cloudservice.v1.CreateNamespaceResponse
-	(*GetNamespacesRequest)(nil),                     // 18: temporal.api.cloud.cloudservice.v1.GetNamespacesRequest
-	(*GetNamespacesResponse)(nil),                    // 19: temporal.api.cloud.cloudservice.v1.GetNamespacesResponse
-	(*GetNamespaceRequest)(nil),                      // 20: temporal.api.cloud.cloudservice.v1.GetNamespaceRequest
-	(*GetNamespaceResponse)(nil),                     // 21: temporal.api.cloud.cloudservice.v1.GetNamespaceResponse
-	(*UpdateNamespaceRequest)(nil),                   // 22: temporal.api.cloud.cloudservice.v1.UpdateNamespaceRequest
-	(*UpdateNamespaceResponse)(nil),                  // 23: temporal.api.cloud.cloudservice.v1.UpdateNamespaceResponse
-	(*RenameCustomSearchAttributeRequest)(nil),       // 24: temporal.api.cloud.cloudservice.v1.RenameCustomSearchAttributeRequest
-	(*RenameCustomSearchAttributeResponse)(nil),      // 25: temporal.api.cloud.cloudservice.v1.RenameCustomSearchAttributeResponse
-	(*DeleteNamespaceRequest)(nil),                   // 26: temporal.api.cloud.cloudservice.v1.DeleteNamespaceRequest
-	(*DeleteNamespaceResponse)(nil),                  // 27: temporal.api.cloud.cloudservice.v1.DeleteNamespaceResponse
-	(*FailoverNamespaceRegionRequest)(nil),           // 28: temporal.api.cloud.cloudservice.v1.FailoverNamespaceRegionRequest
-	(*FailoverNamespaceRegionResponse)(nil),          // 29: temporal.api.cloud.cloudservice.v1.FailoverNamespaceRegionResponse
-	(*AddNamespaceRegionRequest)(nil),                // 30: temporal.api.cloud.cloudservice.v1.AddNamespaceRegionRequest
-	(*AddNamespaceRegionResponse)(nil),               // 31: temporal.api.cloud.cloudservice.v1.AddNamespaceRegionResponse
-	(*DeleteNamespaceRegionRequest)(nil),             // 32: temporal.api.cloud.cloudservice.v1.DeleteNamespaceRegionRequest
-	(*DeleteNamespaceRegionResponse)(nil),            // 33: temporal.api.cloud.cloudservice.v1.DeleteNamespaceRegionResponse
-	(*GetRegionsRequest)(nil),                        // 34: temporal.api.cloud.cloudservice.v1.GetRegionsRequest
-	(*GetRegionsResponse)(nil),                       // 35: temporal.api.cloud.cloudservice.v1.GetRegionsResponse
-	(*GetRegionRequest)(nil),                         // 36: temporal.api.cloud.cloudservice.v1.GetRegionRequest
-	(*GetRegionResponse)(nil),                        // 37: temporal.api.cloud.cloudservice.v1.GetRegionResponse
-	(*GetApiKeysRequest)(nil),                        // 38: temporal.api.cloud.cloudservice.v1.GetApiKeysRequest
-	(*GetApiKeysResponse)(nil),                       // 39: temporal.api.cloud.cloudservice.v1.GetApiKeysResponse
-	(*GetApiKeyRequest)(nil),                         // 40: temporal.api.cloud.cloudservice.v1.GetApiKeyRequest
-	(*GetApiKeyResponse)(nil),                        // 41: temporal.api.cloud.cloudservice.v1.GetApiKeyResponse
-	(*CreateApiKeyRequest)(nil),                      // 42: temporal.api.cloud.cloudservice.v1.CreateApiKeyRequest
-	(*CreateApiKeyResponse)(nil),                     // 43: temporal.api.cloud.cloudservice.v1.CreateApiKeyResponse
-	(*UpdateApiKeyRequest)(nil),                      // 44: temporal.api.cloud.cloudservice.v1.UpdateApiKeyRequest
-	(*UpdateApiKeyResponse)(nil),                     // 45: temporal.api.cloud.cloudservice.v1.UpdateApiKeyResponse
-	(*DeleteApiKeyRequest)(nil),                      // 46: temporal.api.cloud.cloudservice.v1.DeleteApiKeyRequest
-	(*DeleteApiKeyResponse)(nil),                     // 47: temporal.api.cloud.cloudservice.v1.DeleteApiKeyResponse
-	(*GetNexusEndpointsRequest)(nil),                 // 48: temporal.api.cloud.cloudservice.v1.GetNexusEndpointsRequest
-	(*GetNexusEndpointsResponse)(nil),                // 49: temporal.api.cloud.cloudservice.v1.GetNexusEndpointsResponse
-	(*GetNexusEndpointRequest)(nil),                  // 50: temporal.api.cloud.cloudservice.v1.GetNexusEndpointRequest
-	(*GetNexusEndpointResponse)(nil),                 // 51: temporal.api.cloud.cloudservice.v1.GetNexusEndpointResponse
-	(*CreateNexusEndpointRequest)(nil),               // 52: temporal.api.cloud.cloudservice.v1.CreateNexusEndpointRequest
-	(*CreateNexusEndpointResponse)(nil),              // 53: temporal.api.cloud.cloudservice.v1.CreateNexusEndpointResponse
-	(*UpdateNexusEndpointRequest)(nil),               // 54: temporal.api.cloud.cloudservice.v1.UpdateNexusEndpointRequest
-	(*UpdateNexusEndpointResponse)(nil),              // 55: temporal.api.cloud.cloudservice.v1.UpdateNexusEndpointResponse
-	(*DeleteNexusEndpointRequest)(nil),               // 56: temporal.api.cloud.cloudservice.v1.DeleteNexusEndpointRequest
-	(*DeleteNexusEndpointResponse)(nil),              // 57: temporal.api.cloud.cloudservice.v1.DeleteNexusEndpointResponse
-	(*GetUserGroupsRequest)(nil),                     // 58: temporal.api.cloud.cloudservice.v1.GetUserGroupsRequest
-	(*GetUserGroupsResponse)(nil),                    // 59: temporal.api.cloud.cloudservice.v1.GetUserGroupsResponse
-	(*GetUserGroupRequest)(nil),                      // 60: temporal.api.cloud.cloudservice.v1.GetUserGroupRequest
-	(*GetUserGroupResponse)(nil),                     // 61: temporal.api.cloud.cloudservice.v1.GetUserGroupResponse
-	(*CreateUserGroupRequest)(nil),                   // 62: temporal.api.cloud.cloudservice.v1.CreateUserGroupRequest
-	(*CreateUserGroupResponse)(nil),                  // 63: temporal.api.cloud.cloudservice.v1.CreateUserGroupResponse
-	(*UpdateUserGroupRequest)(nil),                   // 64: temporal.api.cloud.cloudservice.v1.UpdateUserGroupRequest
-	(*UpdateUserGroupResponse)(nil),                  // 65: temporal.api.cloud.cloudservice.v1.UpdateUserGroupResponse
-	(*DeleteUserGroupRequest)(nil),                   // 66: temporal.api.cloud.cloudservice.v1.DeleteUserGroupRequest
-	(*DeleteUserGroupResponse)(nil),                  // 67: temporal.api.cloud.cloudservice.v1.DeleteUserGroupResponse
-	(*SetUserGroupNamespaceAccessRequest)(nil),       // 68: temporal.api.cloud.cloudservice.v1.SetUserGroupNamespaceAccessRequest
-	(*SetUserGroupNamespaceAccessResponse)(nil),      // 69: temporal.api.cloud.cloudservice.v1.SetUserGroupNamespaceAccessResponse
-	(*AddUserGroupMemberRequest)(nil),                // 70: temporal.api.cloud.cloudservice.v1.AddUserGroupMemberRequest
-	(*AddUserGroupMemberResponse)(nil),               // 71: temporal.api.cloud.cloudservice.v1.AddUserGroupMemberResponse
-	(*RemoveUserGroupMemberRequest)(nil),             // 72: temporal.api.cloud.cloudservice.v1.RemoveUserGroupMemberRequest
-	(*RemoveUserGroupMemberResponse)(nil),            // 73: temporal.api.cloud.cloudservice.v1.RemoveUserGroupMemberResponse
-	(*GetUserGroupMembersRequest)(nil),               // 74: temporal.api.cloud.cloudservice.v1.GetUserGroupMembersRequest
-	(*GetUserGroupMembersResponse)(nil),              // 75: temporal.api.cloud.cloudservice.v1.GetUserGroupMembersResponse
-	(*CreateServiceAccountRequest)(nil),              // 76: temporal.api.cloud.cloudservice.v1.CreateServiceAccountRequest
-	(*CreateServiceAccountResponse)(nil),             // 77: temporal.api.cloud.cloudservice.v1.CreateServiceAccountResponse
-	(*GetServiceAccountRequest)(nil),                 // 78: temporal.api.cloud.cloudservice.v1.GetServiceAccountRequest
-	(*GetServiceAccountResponse)(nil),                // 79: temporal.api.cloud.cloudservice.v1.GetServiceAccountResponse
-	(*GetServiceAccountsRequest)(nil),                // 80: temporal.api.cloud.cloudservice.v1.GetServiceAccountsRequest
-	(*GetServiceAccountsResponse)(nil),               // 81: temporal.api.cloud.cloudservice.v1.GetServiceAccountsResponse
-	(*UpdateServiceAccountRequest)(nil),              // 82: temporal.api.cloud.cloudservice.v1.UpdateServiceAccountRequest
-	(*UpdateServiceAccountResponse)(nil),             // 83: temporal.api.cloud.cloudservice.v1.UpdateServiceAccountResponse
-	(*SetServiceAccountNamespaceAccessRequest)(nil),  // 84: temporal.api.cloud.cloudservice.v1.SetServiceAccountNamespaceAccessRequest
-	(*SetServiceAccountNamespaceAccessResponse)(nil), // 85: temporal.api.cloud.cloudservice.v1.SetServiceAccountNamespaceAccessResponse
-	(*DeleteServiceAccountRequest)(nil),              // 86: temporal.api.cloud.cloudservice.v1.DeleteServiceAccountRequest
-	(*DeleteServiceAccountResponse)(nil),             // 87: temporal.api.cloud.cloudservice.v1.DeleteServiceAccountResponse
-	(*GetUsageRequest)(nil),                          // 88: temporal.api.cloud.cloudservice.v1.GetUsageRequest
-	(*GetUsageResponse)(nil),                         // 89: temporal.api.cloud.cloudservice.v1.GetUsageResponse
-	(*GetAccountRequest)(nil),                        // 90: temporal.api.cloud.cloudservice.v1.GetAccountRequest
-	(*GetAccountResponse)(nil),                       // 91: temporal.api.cloud.cloudservice.v1.GetAccountResponse
-	(*UpdateAccountRequest)(nil),                     // 92: temporal.api.cloud.cloudservice.v1.UpdateAccountRequest
-	(*UpdateAccountResponse)(nil),                    // 93: temporal.api.cloud.cloudservice.v1.UpdateAccountResponse
-	(*CreateNamespaceExportSinkRequest)(nil),         // 94: temporal.api.cloud.cloudservice.v1.CreateNamespaceExportSinkRequest
-	(*CreateNamespaceExportSinkResponse)(nil),        // 95: temporal.api.cloud.cloudservice.v1.CreateNamespaceExportSinkResponse
-	(*GetNamespaceExportSinkRequest)(nil),            // 96: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinkRequest
-	(*GetNamespaceExportSinkResponse)(nil),           // 97: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinkResponse
-	(*GetNamespaceExportSinksRequest)(nil),           // 98: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinksRequest
-	(*GetNamespaceExportSinksResponse)(nil),          // 99: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinksResponse
-	(*UpdateNamespaceExportSinkRequest)(nil),         // 100: temporal.api.cloud.cloudservice.v1.UpdateNamespaceExportSinkRequest
-	(*UpdateNamespaceExportSinkResponse)(nil),        // 101: temporal.api.cloud.cloudservice.v1.UpdateNamespaceExportSinkResponse
-	(*DeleteNamespaceExportSinkRequest)(nil),         // 102: temporal.api.cloud.cloudservice.v1.DeleteNamespaceExportSinkRequest
-	(*DeleteNamespaceExportSinkResponse)(nil),        // 103: temporal.api.cloud.cloudservice.v1.DeleteNamespaceExportSinkResponse
-	(*ValidateNamespaceExportSinkRequest)(nil),       // 104: temporal.api.cloud.cloudservice.v1.ValidateNamespaceExportSinkRequest
-	(*ValidateNamespaceExportSinkResponse)(nil),      // 105: temporal.api.cloud.cloudservice.v1.ValidateNamespaceExportSinkResponse
-	(*UpdateNamespaceTagsRequest)(nil),               // 106: temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsRequest
-	(*UpdateNamespaceTagsResponse)(nil),              // 107: temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsResponse
-	(*CreateConnectivityRuleRequest)(nil),            // 108: temporal.api.cloud.cloudservice.v1.CreateConnectivityRuleRequest
-	(*CreateConnectivityRuleResponse)(nil),           // 109: temporal.api.cloud.cloudservice.v1.CreateConnectivityRuleResponse
-	(*GetConnectivityRuleRequest)(nil),               // 110: temporal.api.cloud.cloudservice.v1.GetConnectivityRuleRequest
-	(*GetConnectivityRuleResponse)(nil),              // 111: temporal.api.cloud.cloudservice.v1.GetConnectivityRuleResponse
-	(*GetConnectivityRulesRequest)(nil),              // 112: temporal.api.cloud.cloudservice.v1.GetConnectivityRulesRequest
-	(*GetConnectivityRulesResponse)(nil),             // 113: temporal.api.cloud.cloudservice.v1.GetConnectivityRulesResponse
-	(*DeleteConnectivityRuleRequest)(nil),            // 114: temporal.api.cloud.cloudservice.v1.DeleteConnectivityRuleRequest
-	(*DeleteConnectivityRuleResponse)(nil),           // 115: temporal.api.cloud.cloudservice.v1.DeleteConnectivityRuleResponse
-	(*GetAuditLogsRequest)(nil),                      // 116: temporal.api.cloud.cloudservice.v1.GetAuditLogsRequest
-	(*GetAuditLogsResponse)(nil),                     // 117: temporal.api.cloud.cloudservice.v1.GetAuditLogsResponse
-	(*ValidateAccountAuditLogSinkRequest)(nil),       // 118: temporal.api.cloud.cloudservice.v1.ValidateAccountAuditLogSinkRequest
-	(*ValidateAccountAuditLogSinkResponse)(nil),      // 119: temporal.api.cloud.cloudservice.v1.ValidateAccountAuditLogSinkResponse
-	(*CreateAccountAuditLogSinkRequest)(nil),         // 120: temporal.api.cloud.cloudservice.v1.CreateAccountAuditLogSinkRequest
-	(*CreateAccountAuditLogSinkResponse)(nil),        // 121: temporal.api.cloud.cloudservice.v1.CreateAccountAuditLogSinkResponse
-	(*GetAccountAuditLogSinkRequest)(nil),            // 122: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinkRequest
-	(*GetAccountAuditLogSinkResponse)(nil),           // 123: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinkResponse
-	(*GetAccountAuditLogSinksRequest)(nil),           // 124: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinksRequest
-	(*GetAccountAuditLogSinksResponse)(nil),          // 125: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinksResponse
-	(*UpdateAccountAuditLogSinkRequest)(nil),         // 126: temporal.api.cloud.cloudservice.v1.UpdateAccountAuditLogSinkRequest
-	(*UpdateAccountAuditLogSinkResponse)(nil),        // 127: temporal.api.cloud.cloudservice.v1.UpdateAccountAuditLogSinkResponse
-	(*DeleteAccountAuditLogSinkRequest)(nil),         // 128: temporal.api.cloud.cloudservice.v1.DeleteAccountAuditLogSinkRequest
-	(*DeleteAccountAuditLogSinkResponse)(nil),        // 129: temporal.api.cloud.cloudservice.v1.DeleteAccountAuditLogSinkResponse
-	(*GetNamespaceCapacityInfoRequest)(nil),          // 130: temporal.api.cloud.cloudservice.v1.GetNamespaceCapacityInfoRequest
-	(*GetNamespaceCapacityInfoResponse)(nil),         // 131: temporal.api.cloud.cloudservice.v1.GetNamespaceCapacityInfoResponse
-	(*CreateBillingReportRequest)(nil),               // 132: temporal.api.cloud.cloudservice.v1.CreateBillingReportRequest
-	(*CreateBillingReportResponse)(nil),              // 133: temporal.api.cloud.cloudservice.v1.CreateBillingReportResponse
-	(*GetBillingReportRequest)(nil),                  // 134: temporal.api.cloud.cloudservice.v1.GetBillingReportRequest
-	(*GetBillingReportResponse)(nil),                 // 135: temporal.api.cloud.cloudservice.v1.GetBillingReportResponse
-	(*GetCustomRolesRequest)(nil),                    // 136: temporal.api.cloud.cloudservice.v1.GetCustomRolesRequest
-	(*GetCustomRolesResponse)(nil),                   // 137: temporal.api.cloud.cloudservice.v1.GetCustomRolesResponse
-	(*GetCustomRoleRequest)(nil),                     // 138: temporal.api.cloud.cloudservice.v1.GetCustomRoleRequest
-	(*GetCustomRoleResponse)(nil),                    // 139: temporal.api.cloud.cloudservice.v1.GetCustomRoleResponse
-	(*CreateCustomRoleRequest)(nil),                  // 140: temporal.api.cloud.cloudservice.v1.CreateCustomRoleRequest
-	(*CreateCustomRoleResponse)(nil),                 // 141: temporal.api.cloud.cloudservice.v1.CreateCustomRoleResponse
-	(*UpdateCustomRoleRequest)(nil),                  // 142: temporal.api.cloud.cloudservice.v1.UpdateCustomRoleRequest
-	(*UpdateCustomRoleResponse)(nil),                 // 143: temporal.api.cloud.cloudservice.v1.UpdateCustomRoleResponse
-	(*DeleteCustomRoleRequest)(nil),                  // 144: temporal.api.cloud.cloudservice.v1.DeleteCustomRoleRequest
-	(*DeleteCustomRoleResponse)(nil),                 // 145: temporal.api.cloud.cloudservice.v1.DeleteCustomRoleResponse
-	nil,                                              // 146: temporal.api.cloud.cloudservice.v1.CreateNamespaceRequest.TagsEntry
-	(*GetUserGroupsRequest_GoogleGroupFilter)(nil),   // 147: temporal.api.cloud.cloudservice.v1.GetUserGroupsRequest.GoogleGroupFilter
-	(*GetUserGroupsRequest_SCIMGroupFilter)(nil),     // 148: temporal.api.cloud.cloudservice.v1.GetUserGroupsRequest.SCIMGroupFilter
-	nil,                               // 149: temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsRequest.TagsToUpsertEntry
-	(*v1.User)(nil),                   // 150: temporal.api.cloud.identity.v1.User
-	(*v1.ServiceAccount)(nil),         // 151: temporal.api.cloud.identity.v1.ServiceAccount
-	(*v1.ApiKey)(nil),                 // 152: temporal.api.cloud.identity.v1.ApiKey
-	(*v1.UserSpec)(nil),               // 153: temporal.api.cloud.identity.v1.UserSpec
-	(*v11.AsyncOperation)(nil),        // 154: temporal.api.cloud.operation.v1.AsyncOperation
-	(*v1.NamespaceAccess)(nil),        // 155: temporal.api.cloud.identity.v1.NamespaceAccess
-	(*v12.NamespaceSpec)(nil),         // 156: temporal.api.cloud.namespace.v1.NamespaceSpec
-	(*v12.Namespace)(nil),             // 157: temporal.api.cloud.namespace.v1.Namespace
-	(*v13.Region)(nil),                // 158: temporal.api.cloud.region.v1.Region
-	(v1.OwnerType)(0),                 // 159: temporal.api.cloud.identity.v1.OwnerType
-	(*v1.ApiKeySpec)(nil),             // 160: temporal.api.cloud.identity.v1.ApiKeySpec
-	(*v14.Endpoint)(nil),              // 161: temporal.api.cloud.nexus.v1.Endpoint
-	(*v14.EndpointSpec)(nil),          // 162: temporal.api.cloud.nexus.v1.EndpointSpec
-	(*v1.UserGroup)(nil),              // 163: temporal.api.cloud.identity.v1.UserGroup
-	(*v1.UserGroupSpec)(nil),          // 164: temporal.api.cloud.identity.v1.UserGroupSpec
-	(*v1.UserGroupMemberId)(nil),      // 165: temporal.api.cloud.identity.v1.UserGroupMemberId
-	(*v1.UserGroupMember)(nil),        // 166: temporal.api.cloud.identity.v1.UserGroupMember
-	(*v1.ServiceAccountSpec)(nil),     // 167: temporal.api.cloud.identity.v1.ServiceAccountSpec
-	(*timestamppb.Timestamp)(nil),     // 168: google.protobuf.Timestamp
-	(*v15.Summary)(nil),               // 169: temporal.api.cloud.usage.v1.Summary
-	(*v16.Account)(nil),               // 170: temporal.api.cloud.account.v1.Account
-	(*v16.AccountSpec)(nil),           // 171: temporal.api.cloud.account.v1.AccountSpec
-	(*v12.ExportSinkSpec)(nil),        // 172: temporal.api.cloud.namespace.v1.ExportSinkSpec
-	(*v12.ExportSink)(nil),            // 173: temporal.api.cloud.namespace.v1.ExportSink
-	(*v17.ConnectivityRuleSpec)(nil),  // 174: temporal.api.cloud.connectivityrule.v1.ConnectivityRuleSpec
-	(*v17.ConnectivityRule)(nil),      // 175: temporal.api.cloud.connectivityrule.v1.ConnectivityRule
-	(*v18.LogRecord)(nil),             // 176: temporal.api.cloud.auditlog.v1.LogRecord
-	(*v16.AuditLogSinkSpec)(nil),      // 177: temporal.api.cloud.account.v1.AuditLogSinkSpec
-	(*v16.AuditLogSink)(nil),          // 178: temporal.api.cloud.account.v1.AuditLogSink
-	(*v12.NamespaceCapacityInfo)(nil), // 179: temporal.api.cloud.namespace.v1.NamespaceCapacityInfo
-	(*v19.BillingReportSpec)(nil),     // 180: temporal.api.cloud.billing.v1.BillingReportSpec
-	(*v19.BillingReport)(nil),         // 181: temporal.api.cloud.billing.v1.BillingReport
-	(*v1.CustomRole)(nil),             // 182: temporal.api.cloud.identity.v1.CustomRole
-	(*v1.CustomRoleSpec)(nil),         // 183: temporal.api.cloud.identity.v1.CustomRoleSpec
+	(*GetCurrentIdentityRequest)(nil),                     // 0: temporal.api.cloud.cloudservice.v1.GetCurrentIdentityRequest
+	(*GetCurrentIdentityResponse)(nil),                    // 1: temporal.api.cloud.cloudservice.v1.GetCurrentIdentityResponse
+	(*GetUsersRequest)(nil),                               // 2: temporal.api.cloud.cloudservice.v1.GetUsersRequest
+	(*GetUsersResponse)(nil),                              // 3: temporal.api.cloud.cloudservice.v1.GetUsersResponse
+	(*GetUserRequest)(nil),                                // 4: temporal.api.cloud.cloudservice.v1.GetUserRequest
+	(*GetUserResponse)(nil),                               // 5: temporal.api.cloud.cloudservice.v1.GetUserResponse
+	(*CreateUserRequest)(nil),                             // 6: temporal.api.cloud.cloudservice.v1.CreateUserRequest
+	(*CreateUserResponse)(nil),                            // 7: temporal.api.cloud.cloudservice.v1.CreateUserResponse
+	(*UpdateUserRequest)(nil),                             // 8: temporal.api.cloud.cloudservice.v1.UpdateUserRequest
+	(*UpdateUserResponse)(nil),                            // 9: temporal.api.cloud.cloudservice.v1.UpdateUserResponse
+	(*DeleteUserRequest)(nil),                             // 10: temporal.api.cloud.cloudservice.v1.DeleteUserRequest
+	(*DeleteUserResponse)(nil),                            // 11: temporal.api.cloud.cloudservice.v1.DeleteUserResponse
+	(*SetUserNamespaceAccessRequest)(nil),                 // 12: temporal.api.cloud.cloudservice.v1.SetUserNamespaceAccessRequest
+	(*SetUserNamespaceAccessResponse)(nil),                // 13: temporal.api.cloud.cloudservice.v1.SetUserNamespaceAccessResponse
+	(*GetAsyncOperationRequest)(nil),                      // 14: temporal.api.cloud.cloudservice.v1.GetAsyncOperationRequest
+	(*GetAsyncOperationResponse)(nil),                     // 15: temporal.api.cloud.cloudservice.v1.GetAsyncOperationResponse
+	(*CreateNamespaceRequest)(nil),                        // 16: temporal.api.cloud.cloudservice.v1.CreateNamespaceRequest
+	(*CreateNamespaceResponse)(nil),                       // 17: temporal.api.cloud.cloudservice.v1.CreateNamespaceResponse
+	(*GetNamespacesRequest)(nil),                          // 18: temporal.api.cloud.cloudservice.v1.GetNamespacesRequest
+	(*GetNamespacesResponse)(nil),                         // 19: temporal.api.cloud.cloudservice.v1.GetNamespacesResponse
+	(*GetNamespaceRequest)(nil),                           // 20: temporal.api.cloud.cloudservice.v1.GetNamespaceRequest
+	(*GetNamespaceResponse)(nil),                          // 21: temporal.api.cloud.cloudservice.v1.GetNamespaceResponse
+	(*UpdateNamespaceRequest)(nil),                        // 22: temporal.api.cloud.cloudservice.v1.UpdateNamespaceRequest
+	(*UpdateNamespaceResponse)(nil),                       // 23: temporal.api.cloud.cloudservice.v1.UpdateNamespaceResponse
+	(*RenameCustomSearchAttributeRequest)(nil),            // 24: temporal.api.cloud.cloudservice.v1.RenameCustomSearchAttributeRequest
+	(*RenameCustomSearchAttributeResponse)(nil),           // 25: temporal.api.cloud.cloudservice.v1.RenameCustomSearchAttributeResponse
+	(*DeleteNamespaceRequest)(nil),                        // 26: temporal.api.cloud.cloudservice.v1.DeleteNamespaceRequest
+	(*DeleteNamespaceResponse)(nil),                       // 27: temporal.api.cloud.cloudservice.v1.DeleteNamespaceResponse
+	(*FailoverNamespaceRegionRequest)(nil),                // 28: temporal.api.cloud.cloudservice.v1.FailoverNamespaceRegionRequest
+	(*FailoverNamespaceRegionResponse)(nil),               // 29: temporal.api.cloud.cloudservice.v1.FailoverNamespaceRegionResponse
+	(*AddNamespaceRegionRequest)(nil),                     // 30: temporal.api.cloud.cloudservice.v1.AddNamespaceRegionRequest
+	(*AddNamespaceRegionResponse)(nil),                    // 31: temporal.api.cloud.cloudservice.v1.AddNamespaceRegionResponse
+	(*DeleteNamespaceRegionRequest)(nil),                  // 32: temporal.api.cloud.cloudservice.v1.DeleteNamespaceRegionRequest
+	(*DeleteNamespaceRegionResponse)(nil),                 // 33: temporal.api.cloud.cloudservice.v1.DeleteNamespaceRegionResponse
+	(*GetRegionsRequest)(nil),                             // 34: temporal.api.cloud.cloudservice.v1.GetRegionsRequest
+	(*GetRegionsResponse)(nil),                            // 35: temporal.api.cloud.cloudservice.v1.GetRegionsResponse
+	(*GetRegionRequest)(nil),                              // 36: temporal.api.cloud.cloudservice.v1.GetRegionRequest
+	(*GetRegionResponse)(nil),                             // 37: temporal.api.cloud.cloudservice.v1.GetRegionResponse
+	(*GetApiKeysRequest)(nil),                             // 38: temporal.api.cloud.cloudservice.v1.GetApiKeysRequest
+	(*GetApiKeysResponse)(nil),                            // 39: temporal.api.cloud.cloudservice.v1.GetApiKeysResponse
+	(*GetApiKeyRequest)(nil),                              // 40: temporal.api.cloud.cloudservice.v1.GetApiKeyRequest
+	(*GetApiKeyResponse)(nil),                             // 41: temporal.api.cloud.cloudservice.v1.GetApiKeyResponse
+	(*CreateApiKeyRequest)(nil),                           // 42: temporal.api.cloud.cloudservice.v1.CreateApiKeyRequest
+	(*CreateApiKeyResponse)(nil),                          // 43: temporal.api.cloud.cloudservice.v1.CreateApiKeyResponse
+	(*UpdateApiKeyRequest)(nil),                           // 44: temporal.api.cloud.cloudservice.v1.UpdateApiKeyRequest
+	(*UpdateApiKeyResponse)(nil),                          // 45: temporal.api.cloud.cloudservice.v1.UpdateApiKeyResponse
+	(*DeleteApiKeyRequest)(nil),                           // 46: temporal.api.cloud.cloudservice.v1.DeleteApiKeyRequest
+	(*DeleteApiKeyResponse)(nil),                          // 47: temporal.api.cloud.cloudservice.v1.DeleteApiKeyResponse
+	(*GetNexusEndpointsRequest)(nil),                      // 48: temporal.api.cloud.cloudservice.v1.GetNexusEndpointsRequest
+	(*GetNexusEndpointsResponse)(nil),                     // 49: temporal.api.cloud.cloudservice.v1.GetNexusEndpointsResponse
+	(*GetNexusEndpointRequest)(nil),                       // 50: temporal.api.cloud.cloudservice.v1.GetNexusEndpointRequest
+	(*GetNexusEndpointResponse)(nil),                      // 51: temporal.api.cloud.cloudservice.v1.GetNexusEndpointResponse
+	(*CreateNexusEndpointRequest)(nil),                    // 52: temporal.api.cloud.cloudservice.v1.CreateNexusEndpointRequest
+	(*CreateNexusEndpointResponse)(nil),                   // 53: temporal.api.cloud.cloudservice.v1.CreateNexusEndpointResponse
+	(*UpdateNexusEndpointRequest)(nil),                    // 54: temporal.api.cloud.cloudservice.v1.UpdateNexusEndpointRequest
+	(*UpdateNexusEndpointResponse)(nil),                   // 55: temporal.api.cloud.cloudservice.v1.UpdateNexusEndpointResponse
+	(*DeleteNexusEndpointRequest)(nil),                    // 56: temporal.api.cloud.cloudservice.v1.DeleteNexusEndpointRequest
+	(*DeleteNexusEndpointResponse)(nil),                   // 57: temporal.api.cloud.cloudservice.v1.DeleteNexusEndpointResponse
+	(*GetUserGroupsRequest)(nil),                          // 58: temporal.api.cloud.cloudservice.v1.GetUserGroupsRequest
+	(*GetUserGroupsResponse)(nil),                         // 59: temporal.api.cloud.cloudservice.v1.GetUserGroupsResponse
+	(*GetUserGroupRequest)(nil),                           // 60: temporal.api.cloud.cloudservice.v1.GetUserGroupRequest
+	(*GetUserGroupResponse)(nil),                          // 61: temporal.api.cloud.cloudservice.v1.GetUserGroupResponse
+	(*CreateUserGroupRequest)(nil),                        // 62: temporal.api.cloud.cloudservice.v1.CreateUserGroupRequest
+	(*CreateUserGroupResponse)(nil),                       // 63: temporal.api.cloud.cloudservice.v1.CreateUserGroupResponse
+	(*UpdateUserGroupRequest)(nil),                        // 64: temporal.api.cloud.cloudservice.v1.UpdateUserGroupRequest
+	(*UpdateUserGroupResponse)(nil),                       // 65: temporal.api.cloud.cloudservice.v1.UpdateUserGroupResponse
+	(*DeleteUserGroupRequest)(nil),                        // 66: temporal.api.cloud.cloudservice.v1.DeleteUserGroupRequest
+	(*DeleteUserGroupResponse)(nil),                       // 67: temporal.api.cloud.cloudservice.v1.DeleteUserGroupResponse
+	(*SetUserGroupNamespaceAccessRequest)(nil),            // 68: temporal.api.cloud.cloudservice.v1.SetUserGroupNamespaceAccessRequest
+	(*SetUserGroupNamespaceAccessResponse)(nil),           // 69: temporal.api.cloud.cloudservice.v1.SetUserGroupNamespaceAccessResponse
+	(*AddUserGroupMemberRequest)(nil),                     // 70: temporal.api.cloud.cloudservice.v1.AddUserGroupMemberRequest
+	(*AddUserGroupMemberResponse)(nil),                    // 71: temporal.api.cloud.cloudservice.v1.AddUserGroupMemberResponse
+	(*RemoveUserGroupMemberRequest)(nil),                  // 72: temporal.api.cloud.cloudservice.v1.RemoveUserGroupMemberRequest
+	(*RemoveUserGroupMemberResponse)(nil),                 // 73: temporal.api.cloud.cloudservice.v1.RemoveUserGroupMemberResponse
+	(*GetUserGroupMembersRequest)(nil),                    // 74: temporal.api.cloud.cloudservice.v1.GetUserGroupMembersRequest
+	(*GetUserGroupMembersResponse)(nil),                   // 75: temporal.api.cloud.cloudservice.v1.GetUserGroupMembersResponse
+	(*CreateServiceAccountRequest)(nil),                   // 76: temporal.api.cloud.cloudservice.v1.CreateServiceAccountRequest
+	(*CreateServiceAccountResponse)(nil),                  // 77: temporal.api.cloud.cloudservice.v1.CreateServiceAccountResponse
+	(*GetServiceAccountRequest)(nil),                      // 78: temporal.api.cloud.cloudservice.v1.GetServiceAccountRequest
+	(*GetServiceAccountResponse)(nil),                     // 79: temporal.api.cloud.cloudservice.v1.GetServiceAccountResponse
+	(*GetServiceAccountsRequest)(nil),                     // 80: temporal.api.cloud.cloudservice.v1.GetServiceAccountsRequest
+	(*GetServiceAccountsResponse)(nil),                    // 81: temporal.api.cloud.cloudservice.v1.GetServiceAccountsResponse
+	(*UpdateServiceAccountRequest)(nil),                   // 82: temporal.api.cloud.cloudservice.v1.UpdateServiceAccountRequest
+	(*UpdateServiceAccountResponse)(nil),                  // 83: temporal.api.cloud.cloudservice.v1.UpdateServiceAccountResponse
+	(*SetServiceAccountNamespaceAccessRequest)(nil),       // 84: temporal.api.cloud.cloudservice.v1.SetServiceAccountNamespaceAccessRequest
+	(*SetServiceAccountNamespaceAccessResponse)(nil),      // 85: temporal.api.cloud.cloudservice.v1.SetServiceAccountNamespaceAccessResponse
+	(*DeleteServiceAccountRequest)(nil),                   // 86: temporal.api.cloud.cloudservice.v1.DeleteServiceAccountRequest
+	(*DeleteServiceAccountResponse)(nil),                  // 87: temporal.api.cloud.cloudservice.v1.DeleteServiceAccountResponse
+	(*GetUsageRequest)(nil),                               // 88: temporal.api.cloud.cloudservice.v1.GetUsageRequest
+	(*GetUsageResponse)(nil),                              // 89: temporal.api.cloud.cloudservice.v1.GetUsageResponse
+	(*GetAccountRequest)(nil),                             // 90: temporal.api.cloud.cloudservice.v1.GetAccountRequest
+	(*GetAccountResponse)(nil),                            // 91: temporal.api.cloud.cloudservice.v1.GetAccountResponse
+	(*UpdateAccountRequest)(nil),                          // 92: temporal.api.cloud.cloudservice.v1.UpdateAccountRequest
+	(*UpdateAccountResponse)(nil),                         // 93: temporal.api.cloud.cloudservice.v1.UpdateAccountResponse
+	(*CreateNamespaceExportSinkRequest)(nil),              // 94: temporal.api.cloud.cloudservice.v1.CreateNamespaceExportSinkRequest
+	(*CreateNamespaceExportSinkResponse)(nil),             // 95: temporal.api.cloud.cloudservice.v1.CreateNamespaceExportSinkResponse
+	(*GetNamespaceExportSinkRequest)(nil),                 // 96: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinkRequest
+	(*GetNamespaceExportSinkResponse)(nil),                // 97: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinkResponse
+	(*GetNamespaceExportSinksRequest)(nil),                // 98: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinksRequest
+	(*GetNamespaceExportSinksResponse)(nil),               // 99: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinksResponse
+	(*UpdateNamespaceExportSinkRequest)(nil),              // 100: temporal.api.cloud.cloudservice.v1.UpdateNamespaceExportSinkRequest
+	(*UpdateNamespaceExportSinkResponse)(nil),             // 101: temporal.api.cloud.cloudservice.v1.UpdateNamespaceExportSinkResponse
+	(*DeleteNamespaceExportSinkRequest)(nil),              // 102: temporal.api.cloud.cloudservice.v1.DeleteNamespaceExportSinkRequest
+	(*DeleteNamespaceExportSinkResponse)(nil),             // 103: temporal.api.cloud.cloudservice.v1.DeleteNamespaceExportSinkResponse
+	(*ValidateNamespaceExportSinkRequest)(nil),            // 104: temporal.api.cloud.cloudservice.v1.ValidateNamespaceExportSinkRequest
+	(*ValidateNamespaceExportSinkResponse)(nil),           // 105: temporal.api.cloud.cloudservice.v1.ValidateNamespaceExportSinkResponse
+	(*UpdateNamespaceTagsRequest)(nil),                    // 106: temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsRequest
+	(*UpdateNamespaceTagsResponse)(nil),                   // 107: temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsResponse
+	(*CreateConnectivityRuleRequest)(nil),                 // 108: temporal.api.cloud.cloudservice.v1.CreateConnectivityRuleRequest
+	(*CreateConnectivityRuleResponse)(nil),                // 109: temporal.api.cloud.cloudservice.v1.CreateConnectivityRuleResponse
+	(*GetConnectivityRuleRequest)(nil),                    // 110: temporal.api.cloud.cloudservice.v1.GetConnectivityRuleRequest
+	(*GetConnectivityRuleResponse)(nil),                   // 111: temporal.api.cloud.cloudservice.v1.GetConnectivityRuleResponse
+	(*GetConnectivityRulesRequest)(nil),                   // 112: temporal.api.cloud.cloudservice.v1.GetConnectivityRulesRequest
+	(*GetConnectivityRulesResponse)(nil),                  // 113: temporal.api.cloud.cloudservice.v1.GetConnectivityRulesResponse
+	(*DeleteConnectivityRuleRequest)(nil),                 // 114: temporal.api.cloud.cloudservice.v1.DeleteConnectivityRuleRequest
+	(*DeleteConnectivityRuleResponse)(nil),                // 115: temporal.api.cloud.cloudservice.v1.DeleteConnectivityRuleResponse
+	(*GetAuditLogsRequest)(nil),                           // 116: temporal.api.cloud.cloudservice.v1.GetAuditLogsRequest
+	(*GetAuditLogsResponse)(nil),                          // 117: temporal.api.cloud.cloudservice.v1.GetAuditLogsResponse
+	(*ValidateAccountAuditLogSinkRequest)(nil),            // 118: temporal.api.cloud.cloudservice.v1.ValidateAccountAuditLogSinkRequest
+	(*ValidateAccountAuditLogSinkResponse)(nil),           // 119: temporal.api.cloud.cloudservice.v1.ValidateAccountAuditLogSinkResponse
+	(*CreateAccountAuditLogSinkRequest)(nil),              // 120: temporal.api.cloud.cloudservice.v1.CreateAccountAuditLogSinkRequest
+	(*CreateAccountAuditLogSinkResponse)(nil),             // 121: temporal.api.cloud.cloudservice.v1.CreateAccountAuditLogSinkResponse
+	(*GetAccountAuditLogSinkRequest)(nil),                 // 122: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinkRequest
+	(*GetAccountAuditLogSinkResponse)(nil),                // 123: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinkResponse
+	(*GetAccountAuditLogSinksRequest)(nil),                // 124: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinksRequest
+	(*GetAccountAuditLogSinksResponse)(nil),               // 125: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinksResponse
+	(*UpdateAccountAuditLogSinkRequest)(nil),              // 126: temporal.api.cloud.cloudservice.v1.UpdateAccountAuditLogSinkRequest
+	(*UpdateAccountAuditLogSinkResponse)(nil),             // 127: temporal.api.cloud.cloudservice.v1.UpdateAccountAuditLogSinkResponse
+	(*DeleteAccountAuditLogSinkRequest)(nil),              // 128: temporal.api.cloud.cloudservice.v1.DeleteAccountAuditLogSinkRequest
+	(*DeleteAccountAuditLogSinkResponse)(nil),             // 129: temporal.api.cloud.cloudservice.v1.DeleteAccountAuditLogSinkResponse
+	(*GetNamespaceCapacityInfoRequest)(nil),               // 130: temporal.api.cloud.cloudservice.v1.GetNamespaceCapacityInfoRequest
+	(*GetNamespaceCapacityInfoResponse)(nil),              // 131: temporal.api.cloud.cloudservice.v1.GetNamespaceCapacityInfoResponse
+	(*CreateBillingReportRequest)(nil),                    // 132: temporal.api.cloud.cloudservice.v1.CreateBillingReportRequest
+	(*CreateBillingReportResponse)(nil),                   // 133: temporal.api.cloud.cloudservice.v1.CreateBillingReportResponse
+	(*GetBillingReportRequest)(nil),                       // 134: temporal.api.cloud.cloudservice.v1.GetBillingReportRequest
+	(*GetBillingReportResponse)(nil),                      // 135: temporal.api.cloud.cloudservice.v1.GetBillingReportResponse
+	(*GetCustomRolesRequest)(nil),                         // 136: temporal.api.cloud.cloudservice.v1.GetCustomRolesRequest
+	(*GetCustomRolesResponse)(nil),                        // 137: temporal.api.cloud.cloudservice.v1.GetCustomRolesResponse
+	(*GetCustomRoleRequest)(nil),                          // 138: temporal.api.cloud.cloudservice.v1.GetCustomRoleRequest
+	(*GetCustomRoleResponse)(nil),                         // 139: temporal.api.cloud.cloudservice.v1.GetCustomRoleResponse
+	(*CreateCustomRoleRequest)(nil),                       // 140: temporal.api.cloud.cloudservice.v1.CreateCustomRoleRequest
+	(*CreateCustomRoleResponse)(nil),                      // 141: temporal.api.cloud.cloudservice.v1.CreateCustomRoleResponse
+	(*UpdateCustomRoleRequest)(nil),                       // 142: temporal.api.cloud.cloudservice.v1.UpdateCustomRoleRequest
+	(*UpdateCustomRoleResponse)(nil),                      // 143: temporal.api.cloud.cloudservice.v1.UpdateCustomRoleResponse
+	(*DeleteCustomRoleRequest)(nil),                       // 144: temporal.api.cloud.cloudservice.v1.DeleteCustomRoleRequest
+	(*DeleteCustomRoleResponse)(nil),                      // 145: temporal.api.cloud.cloudservice.v1.DeleteCustomRoleResponse
+	(*GetUserNamespaceAssignmentsRequest)(nil),            // 146: temporal.api.cloud.cloudservice.v1.GetUserNamespaceAssignmentsRequest
+	(*GetUserNamespaceAssignmentsResponse)(nil),           // 147: temporal.api.cloud.cloudservice.v1.GetUserNamespaceAssignmentsResponse
+	(*GetServiceAccountNamespaceAssignmentsRequest)(nil),  // 148: temporal.api.cloud.cloudservice.v1.GetServiceAccountNamespaceAssignmentsRequest
+	(*GetServiceAccountNamespaceAssignmentsResponse)(nil), // 149: temporal.api.cloud.cloudservice.v1.GetServiceAccountNamespaceAssignmentsResponse
+	(*GetUserGroupNamespaceAssignmentsRequest)(nil),       // 150: temporal.api.cloud.cloudservice.v1.GetUserGroupNamespaceAssignmentsRequest
+	(*GetUserGroupNamespaceAssignmentsResponse)(nil),      // 151: temporal.api.cloud.cloudservice.v1.GetUserGroupNamespaceAssignmentsResponse
+	nil, // 152: temporal.api.cloud.cloudservice.v1.CreateNamespaceRequest.TagsEntry
+	(*GetUserGroupsRequest_GoogleGroupFilter)(nil), // 153: temporal.api.cloud.cloudservice.v1.GetUserGroupsRequest.GoogleGroupFilter
+	(*GetUserGroupsRequest_SCIMGroupFilter)(nil),   // 154: temporal.api.cloud.cloudservice.v1.GetUserGroupsRequest.SCIMGroupFilter
+	nil,                                          // 155: temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsRequest.TagsToUpsertEntry
+	(*v1.User)(nil),                              // 156: temporal.api.cloud.identity.v1.User
+	(*v1.ServiceAccount)(nil),                    // 157: temporal.api.cloud.identity.v1.ServiceAccount
+	(*v1.ApiKey)(nil),                            // 158: temporal.api.cloud.identity.v1.ApiKey
+	(*v1.UserSpec)(nil),                          // 159: temporal.api.cloud.identity.v1.UserSpec
+	(*v11.AsyncOperation)(nil),                   // 160: temporal.api.cloud.operation.v1.AsyncOperation
+	(*v1.NamespaceAccess)(nil),                   // 161: temporal.api.cloud.identity.v1.NamespaceAccess
+	(*v12.NamespaceSpec)(nil),                    // 162: temporal.api.cloud.namespace.v1.NamespaceSpec
+	(*v12.Namespace)(nil),                        // 163: temporal.api.cloud.namespace.v1.Namespace
+	(*v13.Region)(nil),                           // 164: temporal.api.cloud.region.v1.Region
+	(v1.OwnerType)(0),                            // 165: temporal.api.cloud.identity.v1.OwnerType
+	(*v1.ApiKeySpec)(nil),                        // 166: temporal.api.cloud.identity.v1.ApiKeySpec
+	(*v14.Endpoint)(nil),                         // 167: temporal.api.cloud.nexus.v1.Endpoint
+	(*v14.EndpointSpec)(nil),                     // 168: temporal.api.cloud.nexus.v1.EndpointSpec
+	(*v1.UserGroup)(nil),                         // 169: temporal.api.cloud.identity.v1.UserGroup
+	(*v1.UserGroupSpec)(nil),                     // 170: temporal.api.cloud.identity.v1.UserGroupSpec
+	(*v1.UserGroupMemberId)(nil),                 // 171: temporal.api.cloud.identity.v1.UserGroupMemberId
+	(*v1.UserGroupMember)(nil),                   // 172: temporal.api.cloud.identity.v1.UserGroupMember
+	(*v1.ServiceAccountSpec)(nil),                // 173: temporal.api.cloud.identity.v1.ServiceAccountSpec
+	(*timestamppb.Timestamp)(nil),                // 174: google.protobuf.Timestamp
+	(*v15.Summary)(nil),                          // 175: temporal.api.cloud.usage.v1.Summary
+	(*v16.Account)(nil),                          // 176: temporal.api.cloud.account.v1.Account
+	(*v16.AccountSpec)(nil),                      // 177: temporal.api.cloud.account.v1.AccountSpec
+	(*v12.ExportSinkSpec)(nil),                   // 178: temporal.api.cloud.namespace.v1.ExportSinkSpec
+	(*v12.ExportSink)(nil),                       // 179: temporal.api.cloud.namespace.v1.ExportSink
+	(*v17.ConnectivityRuleSpec)(nil),             // 180: temporal.api.cloud.connectivityrule.v1.ConnectivityRuleSpec
+	(*v17.ConnectivityRule)(nil),                 // 181: temporal.api.cloud.connectivityrule.v1.ConnectivityRule
+	(*v18.LogRecord)(nil),                        // 182: temporal.api.cloud.auditlog.v1.LogRecord
+	(*v16.AuditLogSinkSpec)(nil),                 // 183: temporal.api.cloud.account.v1.AuditLogSinkSpec
+	(*v16.AuditLogSink)(nil),                     // 184: temporal.api.cloud.account.v1.AuditLogSink
+	(*v12.NamespaceCapacityInfo)(nil),            // 185: temporal.api.cloud.namespace.v1.NamespaceCapacityInfo
+	(*v19.BillingReportSpec)(nil),                // 186: temporal.api.cloud.billing.v1.BillingReportSpec
+	(*v19.BillingReport)(nil),                    // 187: temporal.api.cloud.billing.v1.BillingReport
+	(*v1.CustomRole)(nil),                        // 188: temporal.api.cloud.identity.v1.CustomRole
+	(*v1.CustomRoleSpec)(nil),                    // 189: temporal.api.cloud.identity.v1.CustomRoleSpec
+	(*v1.UserNamespaceAssignment)(nil),           // 190: temporal.api.cloud.identity.v1.UserNamespaceAssignment
+	(*v1.ServiceAccountNamespaceAssignment)(nil), // 191: temporal.api.cloud.identity.v1.ServiceAccountNamespaceAssignment
+	(*v1.UserGroupNamespaceAssignment)(nil),      // 192: temporal.api.cloud.identity.v1.UserGroupNamespaceAssignment
 }
 var file_temporal_api_cloud_cloudservice_v1_request_response_proto_depIdxs = []int32{
-	150, // 0: temporal.api.cloud.cloudservice.v1.GetCurrentIdentityResponse.user:type_name -> temporal.api.cloud.identity.v1.User
-	151, // 1: temporal.api.cloud.cloudservice.v1.GetCurrentIdentityResponse.service_account:type_name -> temporal.api.cloud.identity.v1.ServiceAccount
-	152, // 2: temporal.api.cloud.cloudservice.v1.GetCurrentIdentityResponse.principal_api_key:type_name -> temporal.api.cloud.identity.v1.ApiKey
-	150, // 3: temporal.api.cloud.cloudservice.v1.GetUsersResponse.users:type_name -> temporal.api.cloud.identity.v1.User
-	150, // 4: temporal.api.cloud.cloudservice.v1.GetUserResponse.user:type_name -> temporal.api.cloud.identity.v1.User
-	153, // 5: temporal.api.cloud.cloudservice.v1.CreateUserRequest.spec:type_name -> temporal.api.cloud.identity.v1.UserSpec
-	154, // 6: temporal.api.cloud.cloudservice.v1.CreateUserResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	153, // 7: temporal.api.cloud.cloudservice.v1.UpdateUserRequest.spec:type_name -> temporal.api.cloud.identity.v1.UserSpec
-	154, // 8: temporal.api.cloud.cloudservice.v1.UpdateUserResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	154, // 9: temporal.api.cloud.cloudservice.v1.DeleteUserResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	155, // 10: temporal.api.cloud.cloudservice.v1.SetUserNamespaceAccessRequest.access:type_name -> temporal.api.cloud.identity.v1.NamespaceAccess
-	154, // 11: temporal.api.cloud.cloudservice.v1.SetUserNamespaceAccessResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	154, // 12: temporal.api.cloud.cloudservice.v1.GetAsyncOperationResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	156, // 13: temporal.api.cloud.cloudservice.v1.CreateNamespaceRequest.spec:type_name -> temporal.api.cloud.namespace.v1.NamespaceSpec
-	146, // 14: temporal.api.cloud.cloudservice.v1.CreateNamespaceRequest.tags:type_name -> temporal.api.cloud.cloudservice.v1.CreateNamespaceRequest.TagsEntry
-	154, // 15: temporal.api.cloud.cloudservice.v1.CreateNamespaceResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	157, // 16: temporal.api.cloud.cloudservice.v1.GetNamespacesResponse.namespaces:type_name -> temporal.api.cloud.namespace.v1.Namespace
-	157, // 17: temporal.api.cloud.cloudservice.v1.GetNamespaceResponse.namespace:type_name -> temporal.api.cloud.namespace.v1.Namespace
-	156, // 18: temporal.api.cloud.cloudservice.v1.UpdateNamespaceRequest.spec:type_name -> temporal.api.cloud.namespace.v1.NamespaceSpec
-	154, // 19: temporal.api.cloud.cloudservice.v1.UpdateNamespaceResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	154, // 20: temporal.api.cloud.cloudservice.v1.RenameCustomSearchAttributeResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	154, // 21: temporal.api.cloud.cloudservice.v1.DeleteNamespaceResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	154, // 22: temporal.api.cloud.cloudservice.v1.FailoverNamespaceRegionResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	154, // 23: temporal.api.cloud.cloudservice.v1.AddNamespaceRegionResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	154, // 24: temporal.api.cloud.cloudservice.v1.DeleteNamespaceRegionResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	158, // 25: temporal.api.cloud.cloudservice.v1.GetRegionsResponse.regions:type_name -> temporal.api.cloud.region.v1.Region
-	158, // 26: temporal.api.cloud.cloudservice.v1.GetRegionResponse.region:type_name -> temporal.api.cloud.region.v1.Region
-	159, // 27: temporal.api.cloud.cloudservice.v1.GetApiKeysRequest.owner_type:type_name -> temporal.api.cloud.identity.v1.OwnerType
-	152, // 28: temporal.api.cloud.cloudservice.v1.GetApiKeysResponse.api_keys:type_name -> temporal.api.cloud.identity.v1.ApiKey
-	152, // 29: temporal.api.cloud.cloudservice.v1.GetApiKeyResponse.api_key:type_name -> temporal.api.cloud.identity.v1.ApiKey
-	160, // 30: temporal.api.cloud.cloudservice.v1.CreateApiKeyRequest.spec:type_name -> temporal.api.cloud.identity.v1.ApiKeySpec
-	154, // 31: temporal.api.cloud.cloudservice.v1.CreateApiKeyResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	160, // 32: temporal.api.cloud.cloudservice.v1.UpdateApiKeyRequest.spec:type_name -> temporal.api.cloud.identity.v1.ApiKeySpec
-	154, // 33: temporal.api.cloud.cloudservice.v1.UpdateApiKeyResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	154, // 34: temporal.api.cloud.cloudservice.v1.DeleteApiKeyResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	161, // 35: temporal.api.cloud.cloudservice.v1.GetNexusEndpointsResponse.endpoints:type_name -> temporal.api.cloud.nexus.v1.Endpoint
-	161, // 36: temporal.api.cloud.cloudservice.v1.GetNexusEndpointResponse.endpoint:type_name -> temporal.api.cloud.nexus.v1.Endpoint
-	162, // 37: temporal.api.cloud.cloudservice.v1.CreateNexusEndpointRequest.spec:type_name -> temporal.api.cloud.nexus.v1.EndpointSpec
-	154, // 38: temporal.api.cloud.cloudservice.v1.CreateNexusEndpointResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	162, // 39: temporal.api.cloud.cloudservice.v1.UpdateNexusEndpointRequest.spec:type_name -> temporal.api.cloud.nexus.v1.EndpointSpec
-	154, // 40: temporal.api.cloud.cloudservice.v1.UpdateNexusEndpointResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	154, // 41: temporal.api.cloud.cloudservice.v1.DeleteNexusEndpointResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	147, // 42: temporal.api.cloud.cloudservice.v1.GetUserGroupsRequest.google_group:type_name -> temporal.api.cloud.cloudservice.v1.GetUserGroupsRequest.GoogleGroupFilter
-	148, // 43: temporal.api.cloud.cloudservice.v1.GetUserGroupsRequest.scim_group:type_name -> temporal.api.cloud.cloudservice.v1.GetUserGroupsRequest.SCIMGroupFilter
-	163, // 44: temporal.api.cloud.cloudservice.v1.GetUserGroupsResponse.groups:type_name -> temporal.api.cloud.identity.v1.UserGroup
-	163, // 45: temporal.api.cloud.cloudservice.v1.GetUserGroupResponse.group:type_name -> temporal.api.cloud.identity.v1.UserGroup
-	164, // 46: temporal.api.cloud.cloudservice.v1.CreateUserGroupRequest.spec:type_name -> temporal.api.cloud.identity.v1.UserGroupSpec
-	154, // 47: temporal.api.cloud.cloudservice.v1.CreateUserGroupResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	164, // 48: temporal.api.cloud.cloudservice.v1.UpdateUserGroupRequest.spec:type_name -> temporal.api.cloud.identity.v1.UserGroupSpec
-	154, // 49: temporal.api.cloud.cloudservice.v1.UpdateUserGroupResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	154, // 50: temporal.api.cloud.cloudservice.v1.DeleteUserGroupResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	155, // 51: temporal.api.cloud.cloudservice.v1.SetUserGroupNamespaceAccessRequest.access:type_name -> temporal.api.cloud.identity.v1.NamespaceAccess
-	154, // 52: temporal.api.cloud.cloudservice.v1.SetUserGroupNamespaceAccessResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	165, // 53: temporal.api.cloud.cloudservice.v1.AddUserGroupMemberRequest.member_id:type_name -> temporal.api.cloud.identity.v1.UserGroupMemberId
-	154, // 54: temporal.api.cloud.cloudservice.v1.AddUserGroupMemberResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	165, // 55: temporal.api.cloud.cloudservice.v1.RemoveUserGroupMemberRequest.member_id:type_name -> temporal.api.cloud.identity.v1.UserGroupMemberId
-	154, // 56: temporal.api.cloud.cloudservice.v1.RemoveUserGroupMemberResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	166, // 57: temporal.api.cloud.cloudservice.v1.GetUserGroupMembersResponse.members:type_name -> temporal.api.cloud.identity.v1.UserGroupMember
-	167, // 58: temporal.api.cloud.cloudservice.v1.CreateServiceAccountRequest.spec:type_name -> temporal.api.cloud.identity.v1.ServiceAccountSpec
-	154, // 59: temporal.api.cloud.cloudservice.v1.CreateServiceAccountResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	151, // 60: temporal.api.cloud.cloudservice.v1.GetServiceAccountResponse.service_account:type_name -> temporal.api.cloud.identity.v1.ServiceAccount
-	151, // 61: temporal.api.cloud.cloudservice.v1.GetServiceAccountsResponse.service_account:type_name -> temporal.api.cloud.identity.v1.ServiceAccount
-	167, // 62: temporal.api.cloud.cloudservice.v1.UpdateServiceAccountRequest.spec:type_name -> temporal.api.cloud.identity.v1.ServiceAccountSpec
-	154, // 63: temporal.api.cloud.cloudservice.v1.UpdateServiceAccountResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	155, // 64: temporal.api.cloud.cloudservice.v1.SetServiceAccountNamespaceAccessRequest.access:type_name -> temporal.api.cloud.identity.v1.NamespaceAccess
-	154, // 65: temporal.api.cloud.cloudservice.v1.SetServiceAccountNamespaceAccessResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	154, // 66: temporal.api.cloud.cloudservice.v1.DeleteServiceAccountResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	168, // 67: temporal.api.cloud.cloudservice.v1.GetUsageRequest.start_time_inclusive:type_name -> google.protobuf.Timestamp
-	168, // 68: temporal.api.cloud.cloudservice.v1.GetUsageRequest.end_time_exclusive:type_name -> google.protobuf.Timestamp
-	169, // 69: temporal.api.cloud.cloudservice.v1.GetUsageResponse.summaries:type_name -> temporal.api.cloud.usage.v1.Summary
-	170, // 70: temporal.api.cloud.cloudservice.v1.GetAccountResponse.account:type_name -> temporal.api.cloud.account.v1.Account
-	171, // 71: temporal.api.cloud.cloudservice.v1.UpdateAccountRequest.spec:type_name -> temporal.api.cloud.account.v1.AccountSpec
-	154, // 72: temporal.api.cloud.cloudservice.v1.UpdateAccountResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	172, // 73: temporal.api.cloud.cloudservice.v1.CreateNamespaceExportSinkRequest.spec:type_name -> temporal.api.cloud.namespace.v1.ExportSinkSpec
-	154, // 74: temporal.api.cloud.cloudservice.v1.CreateNamespaceExportSinkResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	173, // 75: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinkResponse.sink:type_name -> temporal.api.cloud.namespace.v1.ExportSink
-	173, // 76: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinksResponse.sinks:type_name -> temporal.api.cloud.namespace.v1.ExportSink
-	172, // 77: temporal.api.cloud.cloudservice.v1.UpdateNamespaceExportSinkRequest.spec:type_name -> temporal.api.cloud.namespace.v1.ExportSinkSpec
-	154, // 78: temporal.api.cloud.cloudservice.v1.UpdateNamespaceExportSinkResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	154, // 79: temporal.api.cloud.cloudservice.v1.DeleteNamespaceExportSinkResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	172, // 80: temporal.api.cloud.cloudservice.v1.ValidateNamespaceExportSinkRequest.spec:type_name -> temporal.api.cloud.namespace.v1.ExportSinkSpec
-	149, // 81: temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsRequest.tags_to_upsert:type_name -> temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsRequest.TagsToUpsertEntry
-	154, // 82: temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	174, // 83: temporal.api.cloud.cloudservice.v1.CreateConnectivityRuleRequest.spec:type_name -> temporal.api.cloud.connectivityrule.v1.ConnectivityRuleSpec
-	154, // 84: temporal.api.cloud.cloudservice.v1.CreateConnectivityRuleResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	175, // 85: temporal.api.cloud.cloudservice.v1.GetConnectivityRuleResponse.connectivity_rule:type_name -> temporal.api.cloud.connectivityrule.v1.ConnectivityRule
-	175, // 86: temporal.api.cloud.cloudservice.v1.GetConnectivityRulesResponse.connectivity_rules:type_name -> temporal.api.cloud.connectivityrule.v1.ConnectivityRule
-	154, // 87: temporal.api.cloud.cloudservice.v1.DeleteConnectivityRuleResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	168, // 88: temporal.api.cloud.cloudservice.v1.GetAuditLogsRequest.start_time_inclusive:type_name -> google.protobuf.Timestamp
-	168, // 89: temporal.api.cloud.cloudservice.v1.GetAuditLogsRequest.end_time_exclusive:type_name -> google.protobuf.Timestamp
-	176, // 90: temporal.api.cloud.cloudservice.v1.GetAuditLogsResponse.logs:type_name -> temporal.api.cloud.auditlog.v1.LogRecord
-	177, // 91: temporal.api.cloud.cloudservice.v1.ValidateAccountAuditLogSinkRequest.spec:type_name -> temporal.api.cloud.account.v1.AuditLogSinkSpec
-	177, // 92: temporal.api.cloud.cloudservice.v1.CreateAccountAuditLogSinkRequest.spec:type_name -> temporal.api.cloud.account.v1.AuditLogSinkSpec
-	154, // 93: temporal.api.cloud.cloudservice.v1.CreateAccountAuditLogSinkResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	178, // 94: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinkResponse.sink:type_name -> temporal.api.cloud.account.v1.AuditLogSink
-	178, // 95: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinksResponse.sinks:type_name -> temporal.api.cloud.account.v1.AuditLogSink
-	177, // 96: temporal.api.cloud.cloudservice.v1.UpdateAccountAuditLogSinkRequest.spec:type_name -> temporal.api.cloud.account.v1.AuditLogSinkSpec
-	154, // 97: temporal.api.cloud.cloudservice.v1.UpdateAccountAuditLogSinkResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	154, // 98: temporal.api.cloud.cloudservice.v1.DeleteAccountAuditLogSinkResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	179, // 99: temporal.api.cloud.cloudservice.v1.GetNamespaceCapacityInfoResponse.capacity_info:type_name -> temporal.api.cloud.namespace.v1.NamespaceCapacityInfo
-	180, // 100: temporal.api.cloud.cloudservice.v1.CreateBillingReportRequest.spec:type_name -> temporal.api.cloud.billing.v1.BillingReportSpec
-	154, // 101: temporal.api.cloud.cloudservice.v1.CreateBillingReportResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	181, // 102: temporal.api.cloud.cloudservice.v1.GetBillingReportResponse.billing_report:type_name -> temporal.api.cloud.billing.v1.BillingReport
-	182, // 103: temporal.api.cloud.cloudservice.v1.GetCustomRolesResponse.custom_roles:type_name -> temporal.api.cloud.identity.v1.CustomRole
-	182, // 104: temporal.api.cloud.cloudservice.v1.GetCustomRoleResponse.custom_role:type_name -> temporal.api.cloud.identity.v1.CustomRole
-	183, // 105: temporal.api.cloud.cloudservice.v1.CreateCustomRoleRequest.spec:type_name -> temporal.api.cloud.identity.v1.CustomRoleSpec
-	154, // 106: temporal.api.cloud.cloudservice.v1.CreateCustomRoleResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	183, // 107: temporal.api.cloud.cloudservice.v1.UpdateCustomRoleRequest.spec:type_name -> temporal.api.cloud.identity.v1.CustomRoleSpec
-	154, // 108: temporal.api.cloud.cloudservice.v1.UpdateCustomRoleResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	154, // 109: temporal.api.cloud.cloudservice.v1.DeleteCustomRoleResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
-	110, // [110:110] is the sub-list for method output_type
-	110, // [110:110] is the sub-list for method input_type
-	110, // [110:110] is the sub-list for extension type_name
-	110, // [110:110] is the sub-list for extension extendee
-	0,   // [0:110] is the sub-list for field type_name
+	156, // 0: temporal.api.cloud.cloudservice.v1.GetCurrentIdentityResponse.user:type_name -> temporal.api.cloud.identity.v1.User
+	157, // 1: temporal.api.cloud.cloudservice.v1.GetCurrentIdentityResponse.service_account:type_name -> temporal.api.cloud.identity.v1.ServiceAccount
+	158, // 2: temporal.api.cloud.cloudservice.v1.GetCurrentIdentityResponse.principal_api_key:type_name -> temporal.api.cloud.identity.v1.ApiKey
+	156, // 3: temporal.api.cloud.cloudservice.v1.GetUsersResponse.users:type_name -> temporal.api.cloud.identity.v1.User
+	156, // 4: temporal.api.cloud.cloudservice.v1.GetUserResponse.user:type_name -> temporal.api.cloud.identity.v1.User
+	159, // 5: temporal.api.cloud.cloudservice.v1.CreateUserRequest.spec:type_name -> temporal.api.cloud.identity.v1.UserSpec
+	160, // 6: temporal.api.cloud.cloudservice.v1.CreateUserResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	159, // 7: temporal.api.cloud.cloudservice.v1.UpdateUserRequest.spec:type_name -> temporal.api.cloud.identity.v1.UserSpec
+	160, // 8: temporal.api.cloud.cloudservice.v1.UpdateUserResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	160, // 9: temporal.api.cloud.cloudservice.v1.DeleteUserResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	161, // 10: temporal.api.cloud.cloudservice.v1.SetUserNamespaceAccessRequest.access:type_name -> temporal.api.cloud.identity.v1.NamespaceAccess
+	160, // 11: temporal.api.cloud.cloudservice.v1.SetUserNamespaceAccessResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	160, // 12: temporal.api.cloud.cloudservice.v1.GetAsyncOperationResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	162, // 13: temporal.api.cloud.cloudservice.v1.CreateNamespaceRequest.spec:type_name -> temporal.api.cloud.namespace.v1.NamespaceSpec
+	152, // 14: temporal.api.cloud.cloudservice.v1.CreateNamespaceRequest.tags:type_name -> temporal.api.cloud.cloudservice.v1.CreateNamespaceRequest.TagsEntry
+	160, // 15: temporal.api.cloud.cloudservice.v1.CreateNamespaceResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	163, // 16: temporal.api.cloud.cloudservice.v1.GetNamespacesResponse.namespaces:type_name -> temporal.api.cloud.namespace.v1.Namespace
+	163, // 17: temporal.api.cloud.cloudservice.v1.GetNamespaceResponse.namespace:type_name -> temporal.api.cloud.namespace.v1.Namespace
+	162, // 18: temporal.api.cloud.cloudservice.v1.UpdateNamespaceRequest.spec:type_name -> temporal.api.cloud.namespace.v1.NamespaceSpec
+	160, // 19: temporal.api.cloud.cloudservice.v1.UpdateNamespaceResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	160, // 20: temporal.api.cloud.cloudservice.v1.RenameCustomSearchAttributeResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	160, // 21: temporal.api.cloud.cloudservice.v1.DeleteNamespaceResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	160, // 22: temporal.api.cloud.cloudservice.v1.FailoverNamespaceRegionResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	160, // 23: temporal.api.cloud.cloudservice.v1.AddNamespaceRegionResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	160, // 24: temporal.api.cloud.cloudservice.v1.DeleteNamespaceRegionResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	164, // 25: temporal.api.cloud.cloudservice.v1.GetRegionsResponse.regions:type_name -> temporal.api.cloud.region.v1.Region
+	164, // 26: temporal.api.cloud.cloudservice.v1.GetRegionResponse.region:type_name -> temporal.api.cloud.region.v1.Region
+	165, // 27: temporal.api.cloud.cloudservice.v1.GetApiKeysRequest.owner_type:type_name -> temporal.api.cloud.identity.v1.OwnerType
+	158, // 28: temporal.api.cloud.cloudservice.v1.GetApiKeysResponse.api_keys:type_name -> temporal.api.cloud.identity.v1.ApiKey
+	158, // 29: temporal.api.cloud.cloudservice.v1.GetApiKeyResponse.api_key:type_name -> temporal.api.cloud.identity.v1.ApiKey
+	166, // 30: temporal.api.cloud.cloudservice.v1.CreateApiKeyRequest.spec:type_name -> temporal.api.cloud.identity.v1.ApiKeySpec
+	160, // 31: temporal.api.cloud.cloudservice.v1.CreateApiKeyResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	166, // 32: temporal.api.cloud.cloudservice.v1.UpdateApiKeyRequest.spec:type_name -> temporal.api.cloud.identity.v1.ApiKeySpec
+	160, // 33: temporal.api.cloud.cloudservice.v1.UpdateApiKeyResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	160, // 34: temporal.api.cloud.cloudservice.v1.DeleteApiKeyResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	167, // 35: temporal.api.cloud.cloudservice.v1.GetNexusEndpointsResponse.endpoints:type_name -> temporal.api.cloud.nexus.v1.Endpoint
+	167, // 36: temporal.api.cloud.cloudservice.v1.GetNexusEndpointResponse.endpoint:type_name -> temporal.api.cloud.nexus.v1.Endpoint
+	168, // 37: temporal.api.cloud.cloudservice.v1.CreateNexusEndpointRequest.spec:type_name -> temporal.api.cloud.nexus.v1.EndpointSpec
+	160, // 38: temporal.api.cloud.cloudservice.v1.CreateNexusEndpointResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	168, // 39: temporal.api.cloud.cloudservice.v1.UpdateNexusEndpointRequest.spec:type_name -> temporal.api.cloud.nexus.v1.EndpointSpec
+	160, // 40: temporal.api.cloud.cloudservice.v1.UpdateNexusEndpointResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	160, // 41: temporal.api.cloud.cloudservice.v1.DeleteNexusEndpointResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	153, // 42: temporal.api.cloud.cloudservice.v1.GetUserGroupsRequest.google_group:type_name -> temporal.api.cloud.cloudservice.v1.GetUserGroupsRequest.GoogleGroupFilter
+	154, // 43: temporal.api.cloud.cloudservice.v1.GetUserGroupsRequest.scim_group:type_name -> temporal.api.cloud.cloudservice.v1.GetUserGroupsRequest.SCIMGroupFilter
+	169, // 44: temporal.api.cloud.cloudservice.v1.GetUserGroupsResponse.groups:type_name -> temporal.api.cloud.identity.v1.UserGroup
+	169, // 45: temporal.api.cloud.cloudservice.v1.GetUserGroupResponse.group:type_name -> temporal.api.cloud.identity.v1.UserGroup
+	170, // 46: temporal.api.cloud.cloudservice.v1.CreateUserGroupRequest.spec:type_name -> temporal.api.cloud.identity.v1.UserGroupSpec
+	160, // 47: temporal.api.cloud.cloudservice.v1.CreateUserGroupResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	170, // 48: temporal.api.cloud.cloudservice.v1.UpdateUserGroupRequest.spec:type_name -> temporal.api.cloud.identity.v1.UserGroupSpec
+	160, // 49: temporal.api.cloud.cloudservice.v1.UpdateUserGroupResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	160, // 50: temporal.api.cloud.cloudservice.v1.DeleteUserGroupResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	161, // 51: temporal.api.cloud.cloudservice.v1.SetUserGroupNamespaceAccessRequest.access:type_name -> temporal.api.cloud.identity.v1.NamespaceAccess
+	160, // 52: temporal.api.cloud.cloudservice.v1.SetUserGroupNamespaceAccessResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	171, // 53: temporal.api.cloud.cloudservice.v1.AddUserGroupMemberRequest.member_id:type_name -> temporal.api.cloud.identity.v1.UserGroupMemberId
+	160, // 54: temporal.api.cloud.cloudservice.v1.AddUserGroupMemberResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	171, // 55: temporal.api.cloud.cloudservice.v1.RemoveUserGroupMemberRequest.member_id:type_name -> temporal.api.cloud.identity.v1.UserGroupMemberId
+	160, // 56: temporal.api.cloud.cloudservice.v1.RemoveUserGroupMemberResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	172, // 57: temporal.api.cloud.cloudservice.v1.GetUserGroupMembersResponse.members:type_name -> temporal.api.cloud.identity.v1.UserGroupMember
+	173, // 58: temporal.api.cloud.cloudservice.v1.CreateServiceAccountRequest.spec:type_name -> temporal.api.cloud.identity.v1.ServiceAccountSpec
+	160, // 59: temporal.api.cloud.cloudservice.v1.CreateServiceAccountResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	157, // 60: temporal.api.cloud.cloudservice.v1.GetServiceAccountResponse.service_account:type_name -> temporal.api.cloud.identity.v1.ServiceAccount
+	157, // 61: temporal.api.cloud.cloudservice.v1.GetServiceAccountsResponse.service_account:type_name -> temporal.api.cloud.identity.v1.ServiceAccount
+	173, // 62: temporal.api.cloud.cloudservice.v1.UpdateServiceAccountRequest.spec:type_name -> temporal.api.cloud.identity.v1.ServiceAccountSpec
+	160, // 63: temporal.api.cloud.cloudservice.v1.UpdateServiceAccountResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	161, // 64: temporal.api.cloud.cloudservice.v1.SetServiceAccountNamespaceAccessRequest.access:type_name -> temporal.api.cloud.identity.v1.NamespaceAccess
+	160, // 65: temporal.api.cloud.cloudservice.v1.SetServiceAccountNamespaceAccessResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	160, // 66: temporal.api.cloud.cloudservice.v1.DeleteServiceAccountResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	174, // 67: temporal.api.cloud.cloudservice.v1.GetUsageRequest.start_time_inclusive:type_name -> google.protobuf.Timestamp
+	174, // 68: temporal.api.cloud.cloudservice.v1.GetUsageRequest.end_time_exclusive:type_name -> google.protobuf.Timestamp
+	175, // 69: temporal.api.cloud.cloudservice.v1.GetUsageResponse.summaries:type_name -> temporal.api.cloud.usage.v1.Summary
+	176, // 70: temporal.api.cloud.cloudservice.v1.GetAccountResponse.account:type_name -> temporal.api.cloud.account.v1.Account
+	177, // 71: temporal.api.cloud.cloudservice.v1.UpdateAccountRequest.spec:type_name -> temporal.api.cloud.account.v1.AccountSpec
+	160, // 72: temporal.api.cloud.cloudservice.v1.UpdateAccountResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	178, // 73: temporal.api.cloud.cloudservice.v1.CreateNamespaceExportSinkRequest.spec:type_name -> temporal.api.cloud.namespace.v1.ExportSinkSpec
+	160, // 74: temporal.api.cloud.cloudservice.v1.CreateNamespaceExportSinkResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	179, // 75: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinkResponse.sink:type_name -> temporal.api.cloud.namespace.v1.ExportSink
+	179, // 76: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinksResponse.sinks:type_name -> temporal.api.cloud.namespace.v1.ExportSink
+	178, // 77: temporal.api.cloud.cloudservice.v1.UpdateNamespaceExportSinkRequest.spec:type_name -> temporal.api.cloud.namespace.v1.ExportSinkSpec
+	160, // 78: temporal.api.cloud.cloudservice.v1.UpdateNamespaceExportSinkResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	160, // 79: temporal.api.cloud.cloudservice.v1.DeleteNamespaceExportSinkResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	178, // 80: temporal.api.cloud.cloudservice.v1.ValidateNamespaceExportSinkRequest.spec:type_name -> temporal.api.cloud.namespace.v1.ExportSinkSpec
+	155, // 81: temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsRequest.tags_to_upsert:type_name -> temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsRequest.TagsToUpsertEntry
+	160, // 82: temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	180, // 83: temporal.api.cloud.cloudservice.v1.CreateConnectivityRuleRequest.spec:type_name -> temporal.api.cloud.connectivityrule.v1.ConnectivityRuleSpec
+	160, // 84: temporal.api.cloud.cloudservice.v1.CreateConnectivityRuleResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	181, // 85: temporal.api.cloud.cloudservice.v1.GetConnectivityRuleResponse.connectivity_rule:type_name -> temporal.api.cloud.connectivityrule.v1.ConnectivityRule
+	181, // 86: temporal.api.cloud.cloudservice.v1.GetConnectivityRulesResponse.connectivity_rules:type_name -> temporal.api.cloud.connectivityrule.v1.ConnectivityRule
+	160, // 87: temporal.api.cloud.cloudservice.v1.DeleteConnectivityRuleResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	174, // 88: temporal.api.cloud.cloudservice.v1.GetAuditLogsRequest.start_time_inclusive:type_name -> google.protobuf.Timestamp
+	174, // 89: temporal.api.cloud.cloudservice.v1.GetAuditLogsRequest.end_time_exclusive:type_name -> google.protobuf.Timestamp
+	182, // 90: temporal.api.cloud.cloudservice.v1.GetAuditLogsResponse.logs:type_name -> temporal.api.cloud.auditlog.v1.LogRecord
+	183, // 91: temporal.api.cloud.cloudservice.v1.ValidateAccountAuditLogSinkRequest.spec:type_name -> temporal.api.cloud.account.v1.AuditLogSinkSpec
+	183, // 92: temporal.api.cloud.cloudservice.v1.CreateAccountAuditLogSinkRequest.spec:type_name -> temporal.api.cloud.account.v1.AuditLogSinkSpec
+	160, // 93: temporal.api.cloud.cloudservice.v1.CreateAccountAuditLogSinkResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	184, // 94: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinkResponse.sink:type_name -> temporal.api.cloud.account.v1.AuditLogSink
+	184, // 95: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinksResponse.sinks:type_name -> temporal.api.cloud.account.v1.AuditLogSink
+	183, // 96: temporal.api.cloud.cloudservice.v1.UpdateAccountAuditLogSinkRequest.spec:type_name -> temporal.api.cloud.account.v1.AuditLogSinkSpec
+	160, // 97: temporal.api.cloud.cloudservice.v1.UpdateAccountAuditLogSinkResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	160, // 98: temporal.api.cloud.cloudservice.v1.DeleteAccountAuditLogSinkResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	185, // 99: temporal.api.cloud.cloudservice.v1.GetNamespaceCapacityInfoResponse.capacity_info:type_name -> temporal.api.cloud.namespace.v1.NamespaceCapacityInfo
+	186, // 100: temporal.api.cloud.cloudservice.v1.CreateBillingReportRequest.spec:type_name -> temporal.api.cloud.billing.v1.BillingReportSpec
+	160, // 101: temporal.api.cloud.cloudservice.v1.CreateBillingReportResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	187, // 102: temporal.api.cloud.cloudservice.v1.GetBillingReportResponse.billing_report:type_name -> temporal.api.cloud.billing.v1.BillingReport
+	188, // 103: temporal.api.cloud.cloudservice.v1.GetCustomRolesResponse.custom_roles:type_name -> temporal.api.cloud.identity.v1.CustomRole
+	188, // 104: temporal.api.cloud.cloudservice.v1.GetCustomRoleResponse.custom_role:type_name -> temporal.api.cloud.identity.v1.CustomRole
+	189, // 105: temporal.api.cloud.cloudservice.v1.CreateCustomRoleRequest.spec:type_name -> temporal.api.cloud.identity.v1.CustomRoleSpec
+	160, // 106: temporal.api.cloud.cloudservice.v1.CreateCustomRoleResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	189, // 107: temporal.api.cloud.cloudservice.v1.UpdateCustomRoleRequest.spec:type_name -> temporal.api.cloud.identity.v1.CustomRoleSpec
+	160, // 108: temporal.api.cloud.cloudservice.v1.UpdateCustomRoleResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	160, // 109: temporal.api.cloud.cloudservice.v1.DeleteCustomRoleResponse.async_operation:type_name -> temporal.api.cloud.operation.v1.AsyncOperation
+	190, // 110: temporal.api.cloud.cloudservice.v1.GetUserNamespaceAssignmentsResponse.users:type_name -> temporal.api.cloud.identity.v1.UserNamespaceAssignment
+	191, // 111: temporal.api.cloud.cloudservice.v1.GetServiceAccountNamespaceAssignmentsResponse.service_accounts:type_name -> temporal.api.cloud.identity.v1.ServiceAccountNamespaceAssignment
+	192, // 112: temporal.api.cloud.cloudservice.v1.GetUserGroupNamespaceAssignmentsResponse.groups:type_name -> temporal.api.cloud.identity.v1.UserGroupNamespaceAssignment
+	113, // [113:113] is the sub-list for method output_type
+	113, // [113:113] is the sub-list for method input_type
+	113, // [113:113] is the sub-list for extension type_name
+	113, // [113:113] is the sub-list for extension extendee
+	0,   // [0:113] is the sub-list for field type_name
 }
 
 func init() { file_temporal_api_cloud_cloudservice_v1_request_response_proto_init() }
@@ -9788,7 +10212,7 @@ func file_temporal_api_cloud_cloudservice_v1_request_response_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_temporal_api_cloud_cloudservice_v1_request_response_proto_rawDesc), len(file_temporal_api_cloud_cloudservice_v1_request_response_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   150,
+			NumMessages:   156,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/cloudservice/v1/service.pb.go
+++ b/api/cloudservice/v1/service.pb.go
@@ -39,7 +39,7 @@ var file_temporal_api_cloud_cloudservice_v1_service_proto_rawDesc = string([]byt
 	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x2d, 0x67, 0x65, 0x6e, 0x2d, 0x6f, 0x70, 0x65, 0x6e,
 	0x61, 0x70, 0x69, 0x76, 0x32, 0x2f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2f, 0x61, 0x6e,
 	0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x32,
-	0xc2, 0xcb, 0x01, 0x0a, 0x0c, 0x43, 0x6c, 0x6f, 0x75, 0x64, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63,
+	0x92, 0xd7, 0x01, 0x0a, 0x0c, 0x43, 0x6c, 0x6f, 0x75, 0x64, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63,
 	0x65, 0x12, 0xb0, 0x02, 0x0a, 0x12, 0x47, 0x65, 0x74, 0x43, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x74,
 	0x49, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x12, 0x3d, 0x2e, 0x74, 0x65, 0x6d, 0x70, 0x6f,
 	0x72, 0x61, 0x6c, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2e, 0x63, 0x6c,
@@ -1528,8 +1528,8 @@ var file_temporal_api_cloud_cloudservice_v1_service_proto_rawDesc = string([]byt
 	0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x73, 0x65, 0x72, 0x76,
 	0x69, 0x63, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x42, 0x69, 0x6c,
 	0x6c, 0x69, 0x6e, 0x67, 0x52, 0x65, 0x70, 0x6f, 0x72, 0x74, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e,
-	0x73, 0x65, 0x22, 0xc1, 0x01, 0x92, 0x41, 0x9c, 0x01, 0x0a, 0x07, 0x41, 0x63, 0x63, 0x6f, 0x75,
-	0x6e, 0x74, 0x12, 0x17, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x20, 0x61, 0x20, 0x62, 0x69, 0x6c,
+	0x73, 0x65, 0x22, 0xc1, 0x01, 0x92, 0x41, 0x9c, 0x01, 0x0a, 0x07, 0x42, 0x69, 0x6c, 0x6c, 0x69,
+	0x6e, 0x67, 0x12, 0x17, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x20, 0x61, 0x20, 0x62, 0x69, 0x6c,
 	0x6c, 0x69, 0x6e, 0x67, 0x20, 0x72, 0x65, 0x70, 0x6f, 0x72, 0x74, 0x1a, 0x28, 0x43, 0x72, 0x65,
 	0x61, 0x74, 0x65, 0x73, 0x20, 0x61, 0x20, 0x62, 0x69, 0x6c, 0x6c, 0x69, 0x6e, 0x67, 0x20, 0x72,
 	0x65, 0x70, 0x6f, 0x72, 0x74, 0x20, 0x66, 0x6f, 0x72, 0x20, 0x74, 0x68, 0x65, 0x20, 0x61, 0x63,
@@ -1549,8 +1549,8 @@ var file_temporal_api_cloud_cloudservice_v1_service_proto_rawDesc = string([]byt
 	0x72, 0x61, 0x6c, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2e, 0x63, 0x6c,
 	0x6f, 0x75, 0x64, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x47, 0x65,
 	0x74, 0x42, 0x69, 0x6c, 0x6c, 0x69, 0x6e, 0x67, 0x52, 0x65, 0x70, 0x6f, 0x72, 0x74, 0x52, 0x65,
-	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0xd6, 0x01, 0x92, 0x41, 0xa0, 0x01, 0x0a, 0x07, 0x41,
-	0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x12, 0x14, 0x47, 0x65, 0x74, 0x20, 0x61, 0x20, 0x62, 0x69,
+	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0xd6, 0x01, 0x92, 0x41, 0xa0, 0x01, 0x0a, 0x07, 0x42,
+	0x69, 0x6c, 0x6c, 0x69, 0x6e, 0x67, 0x12, 0x14, 0x47, 0x65, 0x74, 0x20, 0x61, 0x20, 0x62, 0x69,
 	0x6c, 0x6c, 0x69, 0x6e, 0x67, 0x20, 0x72, 0x65, 0x70, 0x6f, 0x72, 0x74, 0x1a, 0x2f, 0x47, 0x65,
 	0x74, 0x73, 0x20, 0x61, 0x6e, 0x20, 0x65, 0x78, 0x69, 0x73, 0x74, 0x69, 0x6e, 0x67, 0x20, 0x62,
 	0x69, 0x6c, 0x6c, 0x69, 0x6e, 0x67, 0x20, 0x72, 0x65, 0x70, 0x6f, 0x72, 0x74, 0x20, 0x66, 0x6f,
@@ -1667,7 +1667,100 @@ var file_temporal_api_cloud_cloudservice_v1_service_proto_rawDesc = string([]byt
 	0x6f, 0x75, 0x64, 0x2f, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x72, 0x6f, 0x6c, 0x65, 0x73,
 	0x82, 0xd3, 0xe4, 0x93, 0x02, 0x1f, 0x2a, 0x1d, 0x2f, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2f, 0x63,
 	0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x72, 0x6f, 0x6c, 0x65, 0x73, 0x2f, 0x7b, 0x72, 0x6f, 0x6c,
-	0x65, 0x5f, 0x69, 0x64, 0x7d, 0x42, 0xc1, 0x15, 0x92, 0x41, 0xfd, 0x13, 0x12, 0xe0, 0x0d, 0x0a,
+	0x65, 0x5f, 0x69, 0x64, 0x7d, 0x12, 0xb9, 0x03, 0x0a, 0x1b, 0x47, 0x65, 0x74, 0x55, 0x73, 0x65,
+	0x72, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x73, 0x73, 0x69, 0x67, 0x6e,
+	0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x46, 0x2e, 0x74, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c,
+	0x2e, 0x61, 0x70, 0x69, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64,
+	0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x47, 0x65, 0x74, 0x55, 0x73,
+	0x65, 0x72, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x73, 0x73, 0x69, 0x67,
+	0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x47, 0x2e,
+	0x74, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x63, 0x6c, 0x6f,
+	0x75, 0x64, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e,
+	0x76, 0x31, 0x2e, 0x47, 0x65, 0x74, 0x55, 0x73, 0x65, 0x72, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70,
+	0x61, 0x63, 0x65, 0x41, 0x73, 0x73, 0x69, 0x67, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x52, 0x65,
+	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x88, 0x02, 0x92, 0x41, 0xce, 0x01, 0x0a, 0x05, 0x55,
+	0x73, 0x65, 0x72, 0x73, 0x12, 0x24, 0x47, 0x65, 0x74, 0x20, 0x75, 0x73, 0x65, 0x72, 0x73, 0x20,
+	0x77, 0x69, 0x74, 0x68, 0x20, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x20, 0x74, 0x6f, 0x20, 0x61,
+	0x20, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x1a, 0x62, 0x52, 0x65, 0x74, 0x75,
+	0x72, 0x6e, 0x73, 0x20, 0x74, 0x68, 0x65, 0x20, 0x75, 0x73, 0x65, 0x72, 0x73, 0x20, 0x74, 0x68,
+	0x61, 0x74, 0x20, 0x68, 0x61, 0x76, 0x65, 0x20, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x20, 0x74,
+	0x6f, 0x20, 0x74, 0x68, 0x65, 0x20, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x2c,
+	0x20, 0x69, 0x6e, 0x63, 0x6c, 0x75, 0x64, 0x69, 0x6e, 0x67, 0x20, 0x65, 0x61, 0x63, 0x68, 0x20,
+	0x75, 0x73, 0x65, 0x72, 0x27, 0x73, 0x20, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65,
+	0x2d, 0x6c, 0x65, 0x76, 0x65, 0x6c, 0x20, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x2e, 0x22, 0x3b,
+	0x0a, 0x13, 0x55, 0x73, 0x65, 0x72, 0x73, 0x20, 0x64, 0x6f, 0x63, 0x75, 0x6d, 0x65, 0x6e, 0x74,
+	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x24, 0x68, 0x74, 0x74, 0x70, 0x73, 0x3a, 0x2f, 0x2f, 0x64,
+	0x6f, 0x63, 0x73, 0x2e, 0x74, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x69, 0x6f, 0x2f,
+	0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2f, 0x75, 0x73, 0x65, 0x72, 0x73, 0x82, 0xd3, 0xe4, 0x93, 0x02,
+	0x30, 0x12, 0x2e, 0x2f, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2f, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70,
+	0x61, 0x63, 0x65, 0x73, 0x2f, 0x7b, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x7d,
+	0x2f, 0x75, 0x73, 0x65, 0x72, 0x2d, 0x61, 0x73, 0x73, 0x69, 0x67, 0x6e, 0x6d, 0x65, 0x6e, 0x74,
+	0x73, 0x12, 0xa5, 0x04, 0x0a, 0x25, 0x47, 0x65, 0x74, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
+	0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65,
+	0x41, 0x73, 0x73, 0x69, 0x67, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x50, 0x2e, 0x74, 0x65,
+	0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64,
+	0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e, 0x76, 0x31,
+	0x2e, 0x47, 0x65, 0x74, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x41, 0x63, 0x63, 0x6f, 0x75,
+	0x6e, 0x74, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x73, 0x73, 0x69, 0x67,
+	0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x51, 0x2e,
+	0x74, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x63, 0x6c, 0x6f,
+	0x75, 0x64, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e,
+	0x76, 0x31, 0x2e, 0x47, 0x65, 0x74, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x41, 0x63, 0x63,
+	0x6f, 0x75, 0x6e, 0x74, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x73, 0x73,
+	0x69, 0x67, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65,
+	0x22, 0xd6, 0x02, 0x92, 0x41, 0x91, 0x02, 0x0a, 0x10, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
+	0x20, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x12, 0x30, 0x4c, 0x69, 0x73, 0x74, 0x20,
+	0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x20, 0x61, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73,
+	0x20, 0x77, 0x69, 0x74, 0x68, 0x20, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x20, 0x74, 0x6f, 0x20,
+	0x61, 0x20, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x1a, 0x78, 0x52, 0x65, 0x74,
+	0x75, 0x72, 0x6e, 0x73, 0x20, 0x74, 0x68, 0x65, 0x20, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
+	0x20, 0x61, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x20, 0x74, 0x68, 0x61, 0x74, 0x20, 0x68,
+	0x61, 0x76, 0x65, 0x20, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x20, 0x74, 0x6f, 0x20, 0x74, 0x68,
+	0x65, 0x20, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x2c, 0x20, 0x69, 0x6e, 0x63,
+	0x6c, 0x75, 0x64, 0x69, 0x6e, 0x67, 0x20, 0x65, 0x61, 0x63, 0x68, 0x20, 0x73, 0x65, 0x72, 0x76,
+	0x69, 0x63, 0x65, 0x20, 0x61, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x27, 0x73, 0x20, 0x6e, 0x61,
+	0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x2d, 0x6c, 0x65, 0x76, 0x65, 0x6c, 0x20, 0x61, 0x63,
+	0x63, 0x65, 0x73, 0x73, 0x2e, 0x22, 0x51, 0x0a, 0x1e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
+	0x20, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x20, 0x64, 0x6f, 0x63, 0x75, 0x6d, 0x65,
+	0x6e, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x2f, 0x68, 0x74, 0x74, 0x70, 0x73, 0x3a, 0x2f,
+	0x2f, 0x64, 0x6f, 0x63, 0x73, 0x2e, 0x74, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x69,
+	0x6f, 0x2f, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2d,
+	0x61, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x3b, 0x12, 0x39,
+	0x2f, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2f, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65,
+	0x73, 0x2f, 0x7b, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x7d, 0x2f, 0x73, 0x65,
+	0x72, 0x76, 0x69, 0x63, 0x65, 0x2d, 0x61, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x2d, 0x61, 0x73,
+	0x73, 0x69, 0x67, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0xe9, 0x03, 0x0a, 0x20, 0x47, 0x65,
+	0x74, 0x55, 0x73, 0x65, 0x72, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70,
+	0x61, 0x63, 0x65, 0x41, 0x73, 0x73, 0x69, 0x67, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x4b,
+	0x2e, 0x74, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x63, 0x6c,
+	0x6f, 0x75, 0x64, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
+	0x2e, 0x76, 0x31, 0x2e, 0x47, 0x65, 0x74, 0x55, 0x73, 0x65, 0x72, 0x47, 0x72, 0x6f, 0x75, 0x70,
+	0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x73, 0x73, 0x69, 0x67, 0x6e, 0x6d,
+	0x65, 0x6e, 0x74, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x4c, 0x2e, 0x74, 0x65,
+	0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64,
+	0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e, 0x76, 0x31,
+	0x2e, 0x47, 0x65, 0x74, 0x55, 0x73, 0x65, 0x72, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x4e, 0x61, 0x6d,
+	0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x73, 0x73, 0x69, 0x67, 0x6e, 0x6d, 0x65, 0x6e, 0x74,
+	0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0xa9, 0x02, 0x92, 0x41, 0xe9, 0x01,
+	0x0a, 0x06, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x73, 0x12, 0x2b, 0x4c, 0x69, 0x73, 0x74, 0x20, 0x75,
+	0x73, 0x65, 0x72, 0x20, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x73, 0x20, 0x77, 0x69, 0x74, 0x68, 0x20,
+	0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x20, 0x74, 0x6f, 0x20, 0x61, 0x20, 0x6e, 0x61, 0x6d, 0x65,
+	0x73, 0x70, 0x61, 0x63, 0x65, 0x1a, 0x69, 0x52, 0x65, 0x74, 0x75, 0x72, 0x6e, 0x73, 0x20, 0x74,
+	0x68, 0x65, 0x20, 0x75, 0x73, 0x65, 0x72, 0x20, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x73, 0x20, 0x74,
+	0x68, 0x61, 0x74, 0x20, 0x68, 0x61, 0x76, 0x65, 0x20, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x20,
+	0x74, 0x6f, 0x20, 0x74, 0x68, 0x65, 0x20, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65,
+	0x2c, 0x20, 0x69, 0x6e, 0x63, 0x6c, 0x75, 0x64, 0x69, 0x6e, 0x67, 0x20, 0x65, 0x61, 0x63, 0x68,
+	0x20, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x27, 0x73, 0x20, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61,
+	0x63, 0x65, 0x2d, 0x6c, 0x65, 0x76, 0x65, 0x6c, 0x20, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x2e,
+	0x22, 0x47, 0x0a, 0x19, 0x55, 0x73, 0x65, 0x72, 0x20, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x73, 0x20,
+	0x64, 0x6f, 0x63, 0x75, 0x6d, 0x65, 0x6e, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x2a, 0x68,
+	0x74, 0x74, 0x70, 0x73, 0x3a, 0x2f, 0x2f, 0x64, 0x6f, 0x63, 0x73, 0x2e, 0x74, 0x65, 0x6d, 0x70,
+	0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x69, 0x6f, 0x2f, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2f, 0x75, 0x73,
+	0x65, 0x72, 0x2d, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x73, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x36, 0x12,
+	0x34, 0x2f, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2f, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63,
+	0x65, 0x73, 0x2f, 0x7b, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x7d, 0x2f, 0x75,
+	0x73, 0x65, 0x72, 0x2d, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x2d, 0x61, 0x73, 0x73, 0x69, 0x67, 0x6e,
+	0x6d, 0x65, 0x6e, 0x74, 0x73, 0x42, 0xc1, 0x15, 0x92, 0x41, 0xfd, 0x13, 0x12, 0xe0, 0x0d, 0x0a,
 	0x16, 0x54, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x20, 0x43, 0x6c, 0x6f, 0x75, 0x64, 0x20,
 	0x4f, 0x70, 0x73, 0x20, 0x41, 0x50, 0x49, 0x12, 0x96, 0x0c, 0x50, 0x72, 0x6f, 0x67, 0x72, 0x61,
 	0x6d, 0x6d, 0x61, 0x74, 0x69, 0x63, 0x20, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x20, 0x74, 0x6f,
@@ -1844,152 +1937,158 @@ var file_temporal_api_cloud_cloudservice_v1_service_proto_rawDesc = string([]byt
 })
 
 var file_temporal_api_cloud_cloudservice_v1_service_proto_goTypes = []any{
-	(*GetCurrentIdentityRequest)(nil),                // 0: temporal.api.cloud.cloudservice.v1.GetCurrentIdentityRequest
-	(*GetUsersRequest)(nil),                          // 1: temporal.api.cloud.cloudservice.v1.GetUsersRequest
-	(*GetUserRequest)(nil),                           // 2: temporal.api.cloud.cloudservice.v1.GetUserRequest
-	(*CreateUserRequest)(nil),                        // 3: temporal.api.cloud.cloudservice.v1.CreateUserRequest
-	(*UpdateUserRequest)(nil),                        // 4: temporal.api.cloud.cloudservice.v1.UpdateUserRequest
-	(*DeleteUserRequest)(nil),                        // 5: temporal.api.cloud.cloudservice.v1.DeleteUserRequest
-	(*SetUserNamespaceAccessRequest)(nil),            // 6: temporal.api.cloud.cloudservice.v1.SetUserNamespaceAccessRequest
-	(*GetAsyncOperationRequest)(nil),                 // 7: temporal.api.cloud.cloudservice.v1.GetAsyncOperationRequest
-	(*CreateNamespaceRequest)(nil),                   // 8: temporal.api.cloud.cloudservice.v1.CreateNamespaceRequest
-	(*GetNamespacesRequest)(nil),                     // 9: temporal.api.cloud.cloudservice.v1.GetNamespacesRequest
-	(*GetNamespaceRequest)(nil),                      // 10: temporal.api.cloud.cloudservice.v1.GetNamespaceRequest
-	(*UpdateNamespaceRequest)(nil),                   // 11: temporal.api.cloud.cloudservice.v1.UpdateNamespaceRequest
-	(*RenameCustomSearchAttributeRequest)(nil),       // 12: temporal.api.cloud.cloudservice.v1.RenameCustomSearchAttributeRequest
-	(*DeleteNamespaceRequest)(nil),                   // 13: temporal.api.cloud.cloudservice.v1.DeleteNamespaceRequest
-	(*FailoverNamespaceRegionRequest)(nil),           // 14: temporal.api.cloud.cloudservice.v1.FailoverNamespaceRegionRequest
-	(*AddNamespaceRegionRequest)(nil),                // 15: temporal.api.cloud.cloudservice.v1.AddNamespaceRegionRequest
-	(*DeleteNamespaceRegionRequest)(nil),             // 16: temporal.api.cloud.cloudservice.v1.DeleteNamespaceRegionRequest
-	(*GetRegionsRequest)(nil),                        // 17: temporal.api.cloud.cloudservice.v1.GetRegionsRequest
-	(*GetRegionRequest)(nil),                         // 18: temporal.api.cloud.cloudservice.v1.GetRegionRequest
-	(*GetApiKeysRequest)(nil),                        // 19: temporal.api.cloud.cloudservice.v1.GetApiKeysRequest
-	(*GetApiKeyRequest)(nil),                         // 20: temporal.api.cloud.cloudservice.v1.GetApiKeyRequest
-	(*CreateApiKeyRequest)(nil),                      // 21: temporal.api.cloud.cloudservice.v1.CreateApiKeyRequest
-	(*UpdateApiKeyRequest)(nil),                      // 22: temporal.api.cloud.cloudservice.v1.UpdateApiKeyRequest
-	(*DeleteApiKeyRequest)(nil),                      // 23: temporal.api.cloud.cloudservice.v1.DeleteApiKeyRequest
-	(*GetNexusEndpointsRequest)(nil),                 // 24: temporal.api.cloud.cloudservice.v1.GetNexusEndpointsRequest
-	(*GetNexusEndpointRequest)(nil),                  // 25: temporal.api.cloud.cloudservice.v1.GetNexusEndpointRequest
-	(*CreateNexusEndpointRequest)(nil),               // 26: temporal.api.cloud.cloudservice.v1.CreateNexusEndpointRequest
-	(*UpdateNexusEndpointRequest)(nil),               // 27: temporal.api.cloud.cloudservice.v1.UpdateNexusEndpointRequest
-	(*DeleteNexusEndpointRequest)(nil),               // 28: temporal.api.cloud.cloudservice.v1.DeleteNexusEndpointRequest
-	(*GetUserGroupsRequest)(nil),                     // 29: temporal.api.cloud.cloudservice.v1.GetUserGroupsRequest
-	(*GetUserGroupRequest)(nil),                      // 30: temporal.api.cloud.cloudservice.v1.GetUserGroupRequest
-	(*CreateUserGroupRequest)(nil),                   // 31: temporal.api.cloud.cloudservice.v1.CreateUserGroupRequest
-	(*UpdateUserGroupRequest)(nil),                   // 32: temporal.api.cloud.cloudservice.v1.UpdateUserGroupRequest
-	(*DeleteUserGroupRequest)(nil),                   // 33: temporal.api.cloud.cloudservice.v1.DeleteUserGroupRequest
-	(*SetUserGroupNamespaceAccessRequest)(nil),       // 34: temporal.api.cloud.cloudservice.v1.SetUserGroupNamespaceAccessRequest
-	(*AddUserGroupMemberRequest)(nil),                // 35: temporal.api.cloud.cloudservice.v1.AddUserGroupMemberRequest
-	(*RemoveUserGroupMemberRequest)(nil),             // 36: temporal.api.cloud.cloudservice.v1.RemoveUserGroupMemberRequest
-	(*GetUserGroupMembersRequest)(nil),               // 37: temporal.api.cloud.cloudservice.v1.GetUserGroupMembersRequest
-	(*CreateServiceAccountRequest)(nil),              // 38: temporal.api.cloud.cloudservice.v1.CreateServiceAccountRequest
-	(*GetServiceAccountRequest)(nil),                 // 39: temporal.api.cloud.cloudservice.v1.GetServiceAccountRequest
-	(*GetServiceAccountsRequest)(nil),                // 40: temporal.api.cloud.cloudservice.v1.GetServiceAccountsRequest
-	(*UpdateServiceAccountRequest)(nil),              // 41: temporal.api.cloud.cloudservice.v1.UpdateServiceAccountRequest
-	(*SetServiceAccountNamespaceAccessRequest)(nil),  // 42: temporal.api.cloud.cloudservice.v1.SetServiceAccountNamespaceAccessRequest
-	(*DeleteServiceAccountRequest)(nil),              // 43: temporal.api.cloud.cloudservice.v1.DeleteServiceAccountRequest
-	(*GetUsageRequest)(nil),                          // 44: temporal.api.cloud.cloudservice.v1.GetUsageRequest
-	(*GetAccountRequest)(nil),                        // 45: temporal.api.cloud.cloudservice.v1.GetAccountRequest
-	(*UpdateAccountRequest)(nil),                     // 46: temporal.api.cloud.cloudservice.v1.UpdateAccountRequest
-	(*CreateNamespaceExportSinkRequest)(nil),         // 47: temporal.api.cloud.cloudservice.v1.CreateNamespaceExportSinkRequest
-	(*GetNamespaceExportSinkRequest)(nil),            // 48: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinkRequest
-	(*GetNamespaceExportSinksRequest)(nil),           // 49: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinksRequest
-	(*UpdateNamespaceExportSinkRequest)(nil),         // 50: temporal.api.cloud.cloudservice.v1.UpdateNamespaceExportSinkRequest
-	(*DeleteNamespaceExportSinkRequest)(nil),         // 51: temporal.api.cloud.cloudservice.v1.DeleteNamespaceExportSinkRequest
-	(*ValidateNamespaceExportSinkRequest)(nil),       // 52: temporal.api.cloud.cloudservice.v1.ValidateNamespaceExportSinkRequest
-	(*UpdateNamespaceTagsRequest)(nil),               // 53: temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsRequest
-	(*CreateConnectivityRuleRequest)(nil),            // 54: temporal.api.cloud.cloudservice.v1.CreateConnectivityRuleRequest
-	(*GetConnectivityRuleRequest)(nil),               // 55: temporal.api.cloud.cloudservice.v1.GetConnectivityRuleRequest
-	(*GetConnectivityRulesRequest)(nil),              // 56: temporal.api.cloud.cloudservice.v1.GetConnectivityRulesRequest
-	(*DeleteConnectivityRuleRequest)(nil),            // 57: temporal.api.cloud.cloudservice.v1.DeleteConnectivityRuleRequest
-	(*GetAuditLogsRequest)(nil),                      // 58: temporal.api.cloud.cloudservice.v1.GetAuditLogsRequest
-	(*ValidateAccountAuditLogSinkRequest)(nil),       // 59: temporal.api.cloud.cloudservice.v1.ValidateAccountAuditLogSinkRequest
-	(*CreateAccountAuditLogSinkRequest)(nil),         // 60: temporal.api.cloud.cloudservice.v1.CreateAccountAuditLogSinkRequest
-	(*GetAccountAuditLogSinkRequest)(nil),            // 61: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinkRequest
-	(*GetAccountAuditLogSinksRequest)(nil),           // 62: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinksRequest
-	(*UpdateAccountAuditLogSinkRequest)(nil),         // 63: temporal.api.cloud.cloudservice.v1.UpdateAccountAuditLogSinkRequest
-	(*DeleteAccountAuditLogSinkRequest)(nil),         // 64: temporal.api.cloud.cloudservice.v1.DeleteAccountAuditLogSinkRequest
-	(*GetNamespaceCapacityInfoRequest)(nil),          // 65: temporal.api.cloud.cloudservice.v1.GetNamespaceCapacityInfoRequest
-	(*CreateBillingReportRequest)(nil),               // 66: temporal.api.cloud.cloudservice.v1.CreateBillingReportRequest
-	(*GetBillingReportRequest)(nil),                  // 67: temporal.api.cloud.cloudservice.v1.GetBillingReportRequest
-	(*GetCustomRolesRequest)(nil),                    // 68: temporal.api.cloud.cloudservice.v1.GetCustomRolesRequest
-	(*GetCustomRoleRequest)(nil),                     // 69: temporal.api.cloud.cloudservice.v1.GetCustomRoleRequest
-	(*CreateCustomRoleRequest)(nil),                  // 70: temporal.api.cloud.cloudservice.v1.CreateCustomRoleRequest
-	(*UpdateCustomRoleRequest)(nil),                  // 71: temporal.api.cloud.cloudservice.v1.UpdateCustomRoleRequest
-	(*DeleteCustomRoleRequest)(nil),                  // 72: temporal.api.cloud.cloudservice.v1.DeleteCustomRoleRequest
-	(*GetCurrentIdentityResponse)(nil),               // 73: temporal.api.cloud.cloudservice.v1.GetCurrentIdentityResponse
-	(*GetUsersResponse)(nil),                         // 74: temporal.api.cloud.cloudservice.v1.GetUsersResponse
-	(*GetUserResponse)(nil),                          // 75: temporal.api.cloud.cloudservice.v1.GetUserResponse
-	(*CreateUserResponse)(nil),                       // 76: temporal.api.cloud.cloudservice.v1.CreateUserResponse
-	(*UpdateUserResponse)(nil),                       // 77: temporal.api.cloud.cloudservice.v1.UpdateUserResponse
-	(*DeleteUserResponse)(nil),                       // 78: temporal.api.cloud.cloudservice.v1.DeleteUserResponse
-	(*SetUserNamespaceAccessResponse)(nil),           // 79: temporal.api.cloud.cloudservice.v1.SetUserNamespaceAccessResponse
-	(*GetAsyncOperationResponse)(nil),                // 80: temporal.api.cloud.cloudservice.v1.GetAsyncOperationResponse
-	(*CreateNamespaceResponse)(nil),                  // 81: temporal.api.cloud.cloudservice.v1.CreateNamespaceResponse
-	(*GetNamespacesResponse)(nil),                    // 82: temporal.api.cloud.cloudservice.v1.GetNamespacesResponse
-	(*GetNamespaceResponse)(nil),                     // 83: temporal.api.cloud.cloudservice.v1.GetNamespaceResponse
-	(*UpdateNamespaceResponse)(nil),                  // 84: temporal.api.cloud.cloudservice.v1.UpdateNamespaceResponse
-	(*RenameCustomSearchAttributeResponse)(nil),      // 85: temporal.api.cloud.cloudservice.v1.RenameCustomSearchAttributeResponse
-	(*DeleteNamespaceResponse)(nil),                  // 86: temporal.api.cloud.cloudservice.v1.DeleteNamespaceResponse
-	(*FailoverNamespaceRegionResponse)(nil),          // 87: temporal.api.cloud.cloudservice.v1.FailoverNamespaceRegionResponse
-	(*AddNamespaceRegionResponse)(nil),               // 88: temporal.api.cloud.cloudservice.v1.AddNamespaceRegionResponse
-	(*DeleteNamespaceRegionResponse)(nil),            // 89: temporal.api.cloud.cloudservice.v1.DeleteNamespaceRegionResponse
-	(*GetRegionsResponse)(nil),                       // 90: temporal.api.cloud.cloudservice.v1.GetRegionsResponse
-	(*GetRegionResponse)(nil),                        // 91: temporal.api.cloud.cloudservice.v1.GetRegionResponse
-	(*GetApiKeysResponse)(nil),                       // 92: temporal.api.cloud.cloudservice.v1.GetApiKeysResponse
-	(*GetApiKeyResponse)(nil),                        // 93: temporal.api.cloud.cloudservice.v1.GetApiKeyResponse
-	(*CreateApiKeyResponse)(nil),                     // 94: temporal.api.cloud.cloudservice.v1.CreateApiKeyResponse
-	(*UpdateApiKeyResponse)(nil),                     // 95: temporal.api.cloud.cloudservice.v1.UpdateApiKeyResponse
-	(*DeleteApiKeyResponse)(nil),                     // 96: temporal.api.cloud.cloudservice.v1.DeleteApiKeyResponse
-	(*GetNexusEndpointsResponse)(nil),                // 97: temporal.api.cloud.cloudservice.v1.GetNexusEndpointsResponse
-	(*GetNexusEndpointResponse)(nil),                 // 98: temporal.api.cloud.cloudservice.v1.GetNexusEndpointResponse
-	(*CreateNexusEndpointResponse)(nil),              // 99: temporal.api.cloud.cloudservice.v1.CreateNexusEndpointResponse
-	(*UpdateNexusEndpointResponse)(nil),              // 100: temporal.api.cloud.cloudservice.v1.UpdateNexusEndpointResponse
-	(*DeleteNexusEndpointResponse)(nil),              // 101: temporal.api.cloud.cloudservice.v1.DeleteNexusEndpointResponse
-	(*GetUserGroupsResponse)(nil),                    // 102: temporal.api.cloud.cloudservice.v1.GetUserGroupsResponse
-	(*GetUserGroupResponse)(nil),                     // 103: temporal.api.cloud.cloudservice.v1.GetUserGroupResponse
-	(*CreateUserGroupResponse)(nil),                  // 104: temporal.api.cloud.cloudservice.v1.CreateUserGroupResponse
-	(*UpdateUserGroupResponse)(nil),                  // 105: temporal.api.cloud.cloudservice.v1.UpdateUserGroupResponse
-	(*DeleteUserGroupResponse)(nil),                  // 106: temporal.api.cloud.cloudservice.v1.DeleteUserGroupResponse
-	(*SetUserGroupNamespaceAccessResponse)(nil),      // 107: temporal.api.cloud.cloudservice.v1.SetUserGroupNamespaceAccessResponse
-	(*AddUserGroupMemberResponse)(nil),               // 108: temporal.api.cloud.cloudservice.v1.AddUserGroupMemberResponse
-	(*RemoveUserGroupMemberResponse)(nil),            // 109: temporal.api.cloud.cloudservice.v1.RemoveUserGroupMemberResponse
-	(*GetUserGroupMembersResponse)(nil),              // 110: temporal.api.cloud.cloudservice.v1.GetUserGroupMembersResponse
-	(*CreateServiceAccountResponse)(nil),             // 111: temporal.api.cloud.cloudservice.v1.CreateServiceAccountResponse
-	(*GetServiceAccountResponse)(nil),                // 112: temporal.api.cloud.cloudservice.v1.GetServiceAccountResponse
-	(*GetServiceAccountsResponse)(nil),               // 113: temporal.api.cloud.cloudservice.v1.GetServiceAccountsResponse
-	(*UpdateServiceAccountResponse)(nil),             // 114: temporal.api.cloud.cloudservice.v1.UpdateServiceAccountResponse
-	(*SetServiceAccountNamespaceAccessResponse)(nil), // 115: temporal.api.cloud.cloudservice.v1.SetServiceAccountNamespaceAccessResponse
-	(*DeleteServiceAccountResponse)(nil),             // 116: temporal.api.cloud.cloudservice.v1.DeleteServiceAccountResponse
-	(*GetUsageResponse)(nil),                         // 117: temporal.api.cloud.cloudservice.v1.GetUsageResponse
-	(*GetAccountResponse)(nil),                       // 118: temporal.api.cloud.cloudservice.v1.GetAccountResponse
-	(*UpdateAccountResponse)(nil),                    // 119: temporal.api.cloud.cloudservice.v1.UpdateAccountResponse
-	(*CreateNamespaceExportSinkResponse)(nil),        // 120: temporal.api.cloud.cloudservice.v1.CreateNamespaceExportSinkResponse
-	(*GetNamespaceExportSinkResponse)(nil),           // 121: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinkResponse
-	(*GetNamespaceExportSinksResponse)(nil),          // 122: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinksResponse
-	(*UpdateNamespaceExportSinkResponse)(nil),        // 123: temporal.api.cloud.cloudservice.v1.UpdateNamespaceExportSinkResponse
-	(*DeleteNamespaceExportSinkResponse)(nil),        // 124: temporal.api.cloud.cloudservice.v1.DeleteNamespaceExportSinkResponse
-	(*ValidateNamespaceExportSinkResponse)(nil),      // 125: temporal.api.cloud.cloudservice.v1.ValidateNamespaceExportSinkResponse
-	(*UpdateNamespaceTagsResponse)(nil),              // 126: temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsResponse
-	(*CreateConnectivityRuleResponse)(nil),           // 127: temporal.api.cloud.cloudservice.v1.CreateConnectivityRuleResponse
-	(*GetConnectivityRuleResponse)(nil),              // 128: temporal.api.cloud.cloudservice.v1.GetConnectivityRuleResponse
-	(*GetConnectivityRulesResponse)(nil),             // 129: temporal.api.cloud.cloudservice.v1.GetConnectivityRulesResponse
-	(*DeleteConnectivityRuleResponse)(nil),           // 130: temporal.api.cloud.cloudservice.v1.DeleteConnectivityRuleResponse
-	(*GetAuditLogsResponse)(nil),                     // 131: temporal.api.cloud.cloudservice.v1.GetAuditLogsResponse
-	(*ValidateAccountAuditLogSinkResponse)(nil),      // 132: temporal.api.cloud.cloudservice.v1.ValidateAccountAuditLogSinkResponse
-	(*CreateAccountAuditLogSinkResponse)(nil),        // 133: temporal.api.cloud.cloudservice.v1.CreateAccountAuditLogSinkResponse
-	(*GetAccountAuditLogSinkResponse)(nil),           // 134: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinkResponse
-	(*GetAccountAuditLogSinksResponse)(nil),          // 135: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinksResponse
-	(*UpdateAccountAuditLogSinkResponse)(nil),        // 136: temporal.api.cloud.cloudservice.v1.UpdateAccountAuditLogSinkResponse
-	(*DeleteAccountAuditLogSinkResponse)(nil),        // 137: temporal.api.cloud.cloudservice.v1.DeleteAccountAuditLogSinkResponse
-	(*GetNamespaceCapacityInfoResponse)(nil),         // 138: temporal.api.cloud.cloudservice.v1.GetNamespaceCapacityInfoResponse
-	(*CreateBillingReportResponse)(nil),              // 139: temporal.api.cloud.cloudservice.v1.CreateBillingReportResponse
-	(*GetBillingReportResponse)(nil),                 // 140: temporal.api.cloud.cloudservice.v1.GetBillingReportResponse
-	(*GetCustomRolesResponse)(nil),                   // 141: temporal.api.cloud.cloudservice.v1.GetCustomRolesResponse
-	(*GetCustomRoleResponse)(nil),                    // 142: temporal.api.cloud.cloudservice.v1.GetCustomRoleResponse
-	(*CreateCustomRoleResponse)(nil),                 // 143: temporal.api.cloud.cloudservice.v1.CreateCustomRoleResponse
-	(*UpdateCustomRoleResponse)(nil),                 // 144: temporal.api.cloud.cloudservice.v1.UpdateCustomRoleResponse
-	(*DeleteCustomRoleResponse)(nil),                 // 145: temporal.api.cloud.cloudservice.v1.DeleteCustomRoleResponse
+	(*GetCurrentIdentityRequest)(nil),                     // 0: temporal.api.cloud.cloudservice.v1.GetCurrentIdentityRequest
+	(*GetUsersRequest)(nil),                               // 1: temporal.api.cloud.cloudservice.v1.GetUsersRequest
+	(*GetUserRequest)(nil),                                // 2: temporal.api.cloud.cloudservice.v1.GetUserRequest
+	(*CreateUserRequest)(nil),                             // 3: temporal.api.cloud.cloudservice.v1.CreateUserRequest
+	(*UpdateUserRequest)(nil),                             // 4: temporal.api.cloud.cloudservice.v1.UpdateUserRequest
+	(*DeleteUserRequest)(nil),                             // 5: temporal.api.cloud.cloudservice.v1.DeleteUserRequest
+	(*SetUserNamespaceAccessRequest)(nil),                 // 6: temporal.api.cloud.cloudservice.v1.SetUserNamespaceAccessRequest
+	(*GetAsyncOperationRequest)(nil),                      // 7: temporal.api.cloud.cloudservice.v1.GetAsyncOperationRequest
+	(*CreateNamespaceRequest)(nil),                        // 8: temporal.api.cloud.cloudservice.v1.CreateNamespaceRequest
+	(*GetNamespacesRequest)(nil),                          // 9: temporal.api.cloud.cloudservice.v1.GetNamespacesRequest
+	(*GetNamespaceRequest)(nil),                           // 10: temporal.api.cloud.cloudservice.v1.GetNamespaceRequest
+	(*UpdateNamespaceRequest)(nil),                        // 11: temporal.api.cloud.cloudservice.v1.UpdateNamespaceRequest
+	(*RenameCustomSearchAttributeRequest)(nil),            // 12: temporal.api.cloud.cloudservice.v1.RenameCustomSearchAttributeRequest
+	(*DeleteNamespaceRequest)(nil),                        // 13: temporal.api.cloud.cloudservice.v1.DeleteNamespaceRequest
+	(*FailoverNamespaceRegionRequest)(nil),                // 14: temporal.api.cloud.cloudservice.v1.FailoverNamespaceRegionRequest
+	(*AddNamespaceRegionRequest)(nil),                     // 15: temporal.api.cloud.cloudservice.v1.AddNamespaceRegionRequest
+	(*DeleteNamespaceRegionRequest)(nil),                  // 16: temporal.api.cloud.cloudservice.v1.DeleteNamespaceRegionRequest
+	(*GetRegionsRequest)(nil),                             // 17: temporal.api.cloud.cloudservice.v1.GetRegionsRequest
+	(*GetRegionRequest)(nil),                              // 18: temporal.api.cloud.cloudservice.v1.GetRegionRequest
+	(*GetApiKeysRequest)(nil),                             // 19: temporal.api.cloud.cloudservice.v1.GetApiKeysRequest
+	(*GetApiKeyRequest)(nil),                              // 20: temporal.api.cloud.cloudservice.v1.GetApiKeyRequest
+	(*CreateApiKeyRequest)(nil),                           // 21: temporal.api.cloud.cloudservice.v1.CreateApiKeyRequest
+	(*UpdateApiKeyRequest)(nil),                           // 22: temporal.api.cloud.cloudservice.v1.UpdateApiKeyRequest
+	(*DeleteApiKeyRequest)(nil),                           // 23: temporal.api.cloud.cloudservice.v1.DeleteApiKeyRequest
+	(*GetNexusEndpointsRequest)(nil),                      // 24: temporal.api.cloud.cloudservice.v1.GetNexusEndpointsRequest
+	(*GetNexusEndpointRequest)(nil),                       // 25: temporal.api.cloud.cloudservice.v1.GetNexusEndpointRequest
+	(*CreateNexusEndpointRequest)(nil),                    // 26: temporal.api.cloud.cloudservice.v1.CreateNexusEndpointRequest
+	(*UpdateNexusEndpointRequest)(nil),                    // 27: temporal.api.cloud.cloudservice.v1.UpdateNexusEndpointRequest
+	(*DeleteNexusEndpointRequest)(nil),                    // 28: temporal.api.cloud.cloudservice.v1.DeleteNexusEndpointRequest
+	(*GetUserGroupsRequest)(nil),                          // 29: temporal.api.cloud.cloudservice.v1.GetUserGroupsRequest
+	(*GetUserGroupRequest)(nil),                           // 30: temporal.api.cloud.cloudservice.v1.GetUserGroupRequest
+	(*CreateUserGroupRequest)(nil),                        // 31: temporal.api.cloud.cloudservice.v1.CreateUserGroupRequest
+	(*UpdateUserGroupRequest)(nil),                        // 32: temporal.api.cloud.cloudservice.v1.UpdateUserGroupRequest
+	(*DeleteUserGroupRequest)(nil),                        // 33: temporal.api.cloud.cloudservice.v1.DeleteUserGroupRequest
+	(*SetUserGroupNamespaceAccessRequest)(nil),            // 34: temporal.api.cloud.cloudservice.v1.SetUserGroupNamespaceAccessRequest
+	(*AddUserGroupMemberRequest)(nil),                     // 35: temporal.api.cloud.cloudservice.v1.AddUserGroupMemberRequest
+	(*RemoveUserGroupMemberRequest)(nil),                  // 36: temporal.api.cloud.cloudservice.v1.RemoveUserGroupMemberRequest
+	(*GetUserGroupMembersRequest)(nil),                    // 37: temporal.api.cloud.cloudservice.v1.GetUserGroupMembersRequest
+	(*CreateServiceAccountRequest)(nil),                   // 38: temporal.api.cloud.cloudservice.v1.CreateServiceAccountRequest
+	(*GetServiceAccountRequest)(nil),                      // 39: temporal.api.cloud.cloudservice.v1.GetServiceAccountRequest
+	(*GetServiceAccountsRequest)(nil),                     // 40: temporal.api.cloud.cloudservice.v1.GetServiceAccountsRequest
+	(*UpdateServiceAccountRequest)(nil),                   // 41: temporal.api.cloud.cloudservice.v1.UpdateServiceAccountRequest
+	(*SetServiceAccountNamespaceAccessRequest)(nil),       // 42: temporal.api.cloud.cloudservice.v1.SetServiceAccountNamespaceAccessRequest
+	(*DeleteServiceAccountRequest)(nil),                   // 43: temporal.api.cloud.cloudservice.v1.DeleteServiceAccountRequest
+	(*GetUsageRequest)(nil),                               // 44: temporal.api.cloud.cloudservice.v1.GetUsageRequest
+	(*GetAccountRequest)(nil),                             // 45: temporal.api.cloud.cloudservice.v1.GetAccountRequest
+	(*UpdateAccountRequest)(nil),                          // 46: temporal.api.cloud.cloudservice.v1.UpdateAccountRequest
+	(*CreateNamespaceExportSinkRequest)(nil),              // 47: temporal.api.cloud.cloudservice.v1.CreateNamespaceExportSinkRequest
+	(*GetNamespaceExportSinkRequest)(nil),                 // 48: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinkRequest
+	(*GetNamespaceExportSinksRequest)(nil),                // 49: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinksRequest
+	(*UpdateNamespaceExportSinkRequest)(nil),              // 50: temporal.api.cloud.cloudservice.v1.UpdateNamespaceExportSinkRequest
+	(*DeleteNamespaceExportSinkRequest)(nil),              // 51: temporal.api.cloud.cloudservice.v1.DeleteNamespaceExportSinkRequest
+	(*ValidateNamespaceExportSinkRequest)(nil),            // 52: temporal.api.cloud.cloudservice.v1.ValidateNamespaceExportSinkRequest
+	(*UpdateNamespaceTagsRequest)(nil),                    // 53: temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsRequest
+	(*CreateConnectivityRuleRequest)(nil),                 // 54: temporal.api.cloud.cloudservice.v1.CreateConnectivityRuleRequest
+	(*GetConnectivityRuleRequest)(nil),                    // 55: temporal.api.cloud.cloudservice.v1.GetConnectivityRuleRequest
+	(*GetConnectivityRulesRequest)(nil),                   // 56: temporal.api.cloud.cloudservice.v1.GetConnectivityRulesRequest
+	(*DeleteConnectivityRuleRequest)(nil),                 // 57: temporal.api.cloud.cloudservice.v1.DeleteConnectivityRuleRequest
+	(*GetAuditLogsRequest)(nil),                           // 58: temporal.api.cloud.cloudservice.v1.GetAuditLogsRequest
+	(*ValidateAccountAuditLogSinkRequest)(nil),            // 59: temporal.api.cloud.cloudservice.v1.ValidateAccountAuditLogSinkRequest
+	(*CreateAccountAuditLogSinkRequest)(nil),              // 60: temporal.api.cloud.cloudservice.v1.CreateAccountAuditLogSinkRequest
+	(*GetAccountAuditLogSinkRequest)(nil),                 // 61: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinkRequest
+	(*GetAccountAuditLogSinksRequest)(nil),                // 62: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinksRequest
+	(*UpdateAccountAuditLogSinkRequest)(nil),              // 63: temporal.api.cloud.cloudservice.v1.UpdateAccountAuditLogSinkRequest
+	(*DeleteAccountAuditLogSinkRequest)(nil),              // 64: temporal.api.cloud.cloudservice.v1.DeleteAccountAuditLogSinkRequest
+	(*GetNamespaceCapacityInfoRequest)(nil),               // 65: temporal.api.cloud.cloudservice.v1.GetNamespaceCapacityInfoRequest
+	(*CreateBillingReportRequest)(nil),                    // 66: temporal.api.cloud.cloudservice.v1.CreateBillingReportRequest
+	(*GetBillingReportRequest)(nil),                       // 67: temporal.api.cloud.cloudservice.v1.GetBillingReportRequest
+	(*GetCustomRolesRequest)(nil),                         // 68: temporal.api.cloud.cloudservice.v1.GetCustomRolesRequest
+	(*GetCustomRoleRequest)(nil),                          // 69: temporal.api.cloud.cloudservice.v1.GetCustomRoleRequest
+	(*CreateCustomRoleRequest)(nil),                       // 70: temporal.api.cloud.cloudservice.v1.CreateCustomRoleRequest
+	(*UpdateCustomRoleRequest)(nil),                       // 71: temporal.api.cloud.cloudservice.v1.UpdateCustomRoleRequest
+	(*DeleteCustomRoleRequest)(nil),                       // 72: temporal.api.cloud.cloudservice.v1.DeleteCustomRoleRequest
+	(*GetUserNamespaceAssignmentsRequest)(nil),            // 73: temporal.api.cloud.cloudservice.v1.GetUserNamespaceAssignmentsRequest
+	(*GetServiceAccountNamespaceAssignmentsRequest)(nil),  // 74: temporal.api.cloud.cloudservice.v1.GetServiceAccountNamespaceAssignmentsRequest
+	(*GetUserGroupNamespaceAssignmentsRequest)(nil),       // 75: temporal.api.cloud.cloudservice.v1.GetUserGroupNamespaceAssignmentsRequest
+	(*GetCurrentIdentityResponse)(nil),                    // 76: temporal.api.cloud.cloudservice.v1.GetCurrentIdentityResponse
+	(*GetUsersResponse)(nil),                              // 77: temporal.api.cloud.cloudservice.v1.GetUsersResponse
+	(*GetUserResponse)(nil),                               // 78: temporal.api.cloud.cloudservice.v1.GetUserResponse
+	(*CreateUserResponse)(nil),                            // 79: temporal.api.cloud.cloudservice.v1.CreateUserResponse
+	(*UpdateUserResponse)(nil),                            // 80: temporal.api.cloud.cloudservice.v1.UpdateUserResponse
+	(*DeleteUserResponse)(nil),                            // 81: temporal.api.cloud.cloudservice.v1.DeleteUserResponse
+	(*SetUserNamespaceAccessResponse)(nil),                // 82: temporal.api.cloud.cloudservice.v1.SetUserNamespaceAccessResponse
+	(*GetAsyncOperationResponse)(nil),                     // 83: temporal.api.cloud.cloudservice.v1.GetAsyncOperationResponse
+	(*CreateNamespaceResponse)(nil),                       // 84: temporal.api.cloud.cloudservice.v1.CreateNamespaceResponse
+	(*GetNamespacesResponse)(nil),                         // 85: temporal.api.cloud.cloudservice.v1.GetNamespacesResponse
+	(*GetNamespaceResponse)(nil),                          // 86: temporal.api.cloud.cloudservice.v1.GetNamespaceResponse
+	(*UpdateNamespaceResponse)(nil),                       // 87: temporal.api.cloud.cloudservice.v1.UpdateNamespaceResponse
+	(*RenameCustomSearchAttributeResponse)(nil),           // 88: temporal.api.cloud.cloudservice.v1.RenameCustomSearchAttributeResponse
+	(*DeleteNamespaceResponse)(nil),                       // 89: temporal.api.cloud.cloudservice.v1.DeleteNamespaceResponse
+	(*FailoverNamespaceRegionResponse)(nil),               // 90: temporal.api.cloud.cloudservice.v1.FailoverNamespaceRegionResponse
+	(*AddNamespaceRegionResponse)(nil),                    // 91: temporal.api.cloud.cloudservice.v1.AddNamespaceRegionResponse
+	(*DeleteNamespaceRegionResponse)(nil),                 // 92: temporal.api.cloud.cloudservice.v1.DeleteNamespaceRegionResponse
+	(*GetRegionsResponse)(nil),                            // 93: temporal.api.cloud.cloudservice.v1.GetRegionsResponse
+	(*GetRegionResponse)(nil),                             // 94: temporal.api.cloud.cloudservice.v1.GetRegionResponse
+	(*GetApiKeysResponse)(nil),                            // 95: temporal.api.cloud.cloudservice.v1.GetApiKeysResponse
+	(*GetApiKeyResponse)(nil),                             // 96: temporal.api.cloud.cloudservice.v1.GetApiKeyResponse
+	(*CreateApiKeyResponse)(nil),                          // 97: temporal.api.cloud.cloudservice.v1.CreateApiKeyResponse
+	(*UpdateApiKeyResponse)(nil),                          // 98: temporal.api.cloud.cloudservice.v1.UpdateApiKeyResponse
+	(*DeleteApiKeyResponse)(nil),                          // 99: temporal.api.cloud.cloudservice.v1.DeleteApiKeyResponse
+	(*GetNexusEndpointsResponse)(nil),                     // 100: temporal.api.cloud.cloudservice.v1.GetNexusEndpointsResponse
+	(*GetNexusEndpointResponse)(nil),                      // 101: temporal.api.cloud.cloudservice.v1.GetNexusEndpointResponse
+	(*CreateNexusEndpointResponse)(nil),                   // 102: temporal.api.cloud.cloudservice.v1.CreateNexusEndpointResponse
+	(*UpdateNexusEndpointResponse)(nil),                   // 103: temporal.api.cloud.cloudservice.v1.UpdateNexusEndpointResponse
+	(*DeleteNexusEndpointResponse)(nil),                   // 104: temporal.api.cloud.cloudservice.v1.DeleteNexusEndpointResponse
+	(*GetUserGroupsResponse)(nil),                         // 105: temporal.api.cloud.cloudservice.v1.GetUserGroupsResponse
+	(*GetUserGroupResponse)(nil),                          // 106: temporal.api.cloud.cloudservice.v1.GetUserGroupResponse
+	(*CreateUserGroupResponse)(nil),                       // 107: temporal.api.cloud.cloudservice.v1.CreateUserGroupResponse
+	(*UpdateUserGroupResponse)(nil),                       // 108: temporal.api.cloud.cloudservice.v1.UpdateUserGroupResponse
+	(*DeleteUserGroupResponse)(nil),                       // 109: temporal.api.cloud.cloudservice.v1.DeleteUserGroupResponse
+	(*SetUserGroupNamespaceAccessResponse)(nil),           // 110: temporal.api.cloud.cloudservice.v1.SetUserGroupNamespaceAccessResponse
+	(*AddUserGroupMemberResponse)(nil),                    // 111: temporal.api.cloud.cloudservice.v1.AddUserGroupMemberResponse
+	(*RemoveUserGroupMemberResponse)(nil),                 // 112: temporal.api.cloud.cloudservice.v1.RemoveUserGroupMemberResponse
+	(*GetUserGroupMembersResponse)(nil),                   // 113: temporal.api.cloud.cloudservice.v1.GetUserGroupMembersResponse
+	(*CreateServiceAccountResponse)(nil),                  // 114: temporal.api.cloud.cloudservice.v1.CreateServiceAccountResponse
+	(*GetServiceAccountResponse)(nil),                     // 115: temporal.api.cloud.cloudservice.v1.GetServiceAccountResponse
+	(*GetServiceAccountsResponse)(nil),                    // 116: temporal.api.cloud.cloudservice.v1.GetServiceAccountsResponse
+	(*UpdateServiceAccountResponse)(nil),                  // 117: temporal.api.cloud.cloudservice.v1.UpdateServiceAccountResponse
+	(*SetServiceAccountNamespaceAccessResponse)(nil),      // 118: temporal.api.cloud.cloudservice.v1.SetServiceAccountNamespaceAccessResponse
+	(*DeleteServiceAccountResponse)(nil),                  // 119: temporal.api.cloud.cloudservice.v1.DeleteServiceAccountResponse
+	(*GetUsageResponse)(nil),                              // 120: temporal.api.cloud.cloudservice.v1.GetUsageResponse
+	(*GetAccountResponse)(nil),                            // 121: temporal.api.cloud.cloudservice.v1.GetAccountResponse
+	(*UpdateAccountResponse)(nil),                         // 122: temporal.api.cloud.cloudservice.v1.UpdateAccountResponse
+	(*CreateNamespaceExportSinkResponse)(nil),             // 123: temporal.api.cloud.cloudservice.v1.CreateNamespaceExportSinkResponse
+	(*GetNamespaceExportSinkResponse)(nil),                // 124: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinkResponse
+	(*GetNamespaceExportSinksResponse)(nil),               // 125: temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinksResponse
+	(*UpdateNamespaceExportSinkResponse)(nil),             // 126: temporal.api.cloud.cloudservice.v1.UpdateNamespaceExportSinkResponse
+	(*DeleteNamespaceExportSinkResponse)(nil),             // 127: temporal.api.cloud.cloudservice.v1.DeleteNamespaceExportSinkResponse
+	(*ValidateNamespaceExportSinkResponse)(nil),           // 128: temporal.api.cloud.cloudservice.v1.ValidateNamespaceExportSinkResponse
+	(*UpdateNamespaceTagsResponse)(nil),                   // 129: temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsResponse
+	(*CreateConnectivityRuleResponse)(nil),                // 130: temporal.api.cloud.cloudservice.v1.CreateConnectivityRuleResponse
+	(*GetConnectivityRuleResponse)(nil),                   // 131: temporal.api.cloud.cloudservice.v1.GetConnectivityRuleResponse
+	(*GetConnectivityRulesResponse)(nil),                  // 132: temporal.api.cloud.cloudservice.v1.GetConnectivityRulesResponse
+	(*DeleteConnectivityRuleResponse)(nil),                // 133: temporal.api.cloud.cloudservice.v1.DeleteConnectivityRuleResponse
+	(*GetAuditLogsResponse)(nil),                          // 134: temporal.api.cloud.cloudservice.v1.GetAuditLogsResponse
+	(*ValidateAccountAuditLogSinkResponse)(nil),           // 135: temporal.api.cloud.cloudservice.v1.ValidateAccountAuditLogSinkResponse
+	(*CreateAccountAuditLogSinkResponse)(nil),             // 136: temporal.api.cloud.cloudservice.v1.CreateAccountAuditLogSinkResponse
+	(*GetAccountAuditLogSinkResponse)(nil),                // 137: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinkResponse
+	(*GetAccountAuditLogSinksResponse)(nil),               // 138: temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinksResponse
+	(*UpdateAccountAuditLogSinkResponse)(nil),             // 139: temporal.api.cloud.cloudservice.v1.UpdateAccountAuditLogSinkResponse
+	(*DeleteAccountAuditLogSinkResponse)(nil),             // 140: temporal.api.cloud.cloudservice.v1.DeleteAccountAuditLogSinkResponse
+	(*GetNamespaceCapacityInfoResponse)(nil),              // 141: temporal.api.cloud.cloudservice.v1.GetNamespaceCapacityInfoResponse
+	(*CreateBillingReportResponse)(nil),                   // 142: temporal.api.cloud.cloudservice.v1.CreateBillingReportResponse
+	(*GetBillingReportResponse)(nil),                      // 143: temporal.api.cloud.cloudservice.v1.GetBillingReportResponse
+	(*GetCustomRolesResponse)(nil),                        // 144: temporal.api.cloud.cloudservice.v1.GetCustomRolesResponse
+	(*GetCustomRoleResponse)(nil),                         // 145: temporal.api.cloud.cloudservice.v1.GetCustomRoleResponse
+	(*CreateCustomRoleResponse)(nil),                      // 146: temporal.api.cloud.cloudservice.v1.CreateCustomRoleResponse
+	(*UpdateCustomRoleResponse)(nil),                      // 147: temporal.api.cloud.cloudservice.v1.UpdateCustomRoleResponse
+	(*DeleteCustomRoleResponse)(nil),                      // 148: temporal.api.cloud.cloudservice.v1.DeleteCustomRoleResponse
+	(*GetUserNamespaceAssignmentsResponse)(nil),           // 149: temporal.api.cloud.cloudservice.v1.GetUserNamespaceAssignmentsResponse
+	(*GetServiceAccountNamespaceAssignmentsResponse)(nil), // 150: temporal.api.cloud.cloudservice.v1.GetServiceAccountNamespaceAssignmentsResponse
+	(*GetUserGroupNamespaceAssignmentsResponse)(nil),      // 151: temporal.api.cloud.cloudservice.v1.GetUserGroupNamespaceAssignmentsResponse
 }
 var file_temporal_api_cloud_cloudservice_v1_service_proto_depIdxs = []int32{
 	0,   // 0: temporal.api.cloud.cloudservice.v1.CloudService.GetCurrentIdentity:input_type -> temporal.api.cloud.cloudservice.v1.GetCurrentIdentityRequest
@@ -2065,81 +2164,87 @@ var file_temporal_api_cloud_cloudservice_v1_service_proto_depIdxs = []int32{
 	70,  // 70: temporal.api.cloud.cloudservice.v1.CloudService.CreateCustomRole:input_type -> temporal.api.cloud.cloudservice.v1.CreateCustomRoleRequest
 	71,  // 71: temporal.api.cloud.cloudservice.v1.CloudService.UpdateCustomRole:input_type -> temporal.api.cloud.cloudservice.v1.UpdateCustomRoleRequest
 	72,  // 72: temporal.api.cloud.cloudservice.v1.CloudService.DeleteCustomRole:input_type -> temporal.api.cloud.cloudservice.v1.DeleteCustomRoleRequest
-	73,  // 73: temporal.api.cloud.cloudservice.v1.CloudService.GetCurrentIdentity:output_type -> temporal.api.cloud.cloudservice.v1.GetCurrentIdentityResponse
-	74,  // 74: temporal.api.cloud.cloudservice.v1.CloudService.GetUsers:output_type -> temporal.api.cloud.cloudservice.v1.GetUsersResponse
-	75,  // 75: temporal.api.cloud.cloudservice.v1.CloudService.GetUser:output_type -> temporal.api.cloud.cloudservice.v1.GetUserResponse
-	76,  // 76: temporal.api.cloud.cloudservice.v1.CloudService.CreateUser:output_type -> temporal.api.cloud.cloudservice.v1.CreateUserResponse
-	77,  // 77: temporal.api.cloud.cloudservice.v1.CloudService.UpdateUser:output_type -> temporal.api.cloud.cloudservice.v1.UpdateUserResponse
-	78,  // 78: temporal.api.cloud.cloudservice.v1.CloudService.DeleteUser:output_type -> temporal.api.cloud.cloudservice.v1.DeleteUserResponse
-	79,  // 79: temporal.api.cloud.cloudservice.v1.CloudService.SetUserNamespaceAccess:output_type -> temporal.api.cloud.cloudservice.v1.SetUserNamespaceAccessResponse
-	80,  // 80: temporal.api.cloud.cloudservice.v1.CloudService.GetAsyncOperation:output_type -> temporal.api.cloud.cloudservice.v1.GetAsyncOperationResponse
-	81,  // 81: temporal.api.cloud.cloudservice.v1.CloudService.CreateNamespace:output_type -> temporal.api.cloud.cloudservice.v1.CreateNamespaceResponse
-	82,  // 82: temporal.api.cloud.cloudservice.v1.CloudService.GetNamespaces:output_type -> temporal.api.cloud.cloudservice.v1.GetNamespacesResponse
-	83,  // 83: temporal.api.cloud.cloudservice.v1.CloudService.GetNamespace:output_type -> temporal.api.cloud.cloudservice.v1.GetNamespaceResponse
-	84,  // 84: temporal.api.cloud.cloudservice.v1.CloudService.UpdateNamespace:output_type -> temporal.api.cloud.cloudservice.v1.UpdateNamespaceResponse
-	85,  // 85: temporal.api.cloud.cloudservice.v1.CloudService.RenameCustomSearchAttribute:output_type -> temporal.api.cloud.cloudservice.v1.RenameCustomSearchAttributeResponse
-	86,  // 86: temporal.api.cloud.cloudservice.v1.CloudService.DeleteNamespace:output_type -> temporal.api.cloud.cloudservice.v1.DeleteNamespaceResponse
-	87,  // 87: temporal.api.cloud.cloudservice.v1.CloudService.FailoverNamespaceRegion:output_type -> temporal.api.cloud.cloudservice.v1.FailoverNamespaceRegionResponse
-	88,  // 88: temporal.api.cloud.cloudservice.v1.CloudService.AddNamespaceRegion:output_type -> temporal.api.cloud.cloudservice.v1.AddNamespaceRegionResponse
-	89,  // 89: temporal.api.cloud.cloudservice.v1.CloudService.DeleteNamespaceRegion:output_type -> temporal.api.cloud.cloudservice.v1.DeleteNamespaceRegionResponse
-	90,  // 90: temporal.api.cloud.cloudservice.v1.CloudService.GetRegions:output_type -> temporal.api.cloud.cloudservice.v1.GetRegionsResponse
-	91,  // 91: temporal.api.cloud.cloudservice.v1.CloudService.GetRegion:output_type -> temporal.api.cloud.cloudservice.v1.GetRegionResponse
-	92,  // 92: temporal.api.cloud.cloudservice.v1.CloudService.GetApiKeys:output_type -> temporal.api.cloud.cloudservice.v1.GetApiKeysResponse
-	93,  // 93: temporal.api.cloud.cloudservice.v1.CloudService.GetApiKey:output_type -> temporal.api.cloud.cloudservice.v1.GetApiKeyResponse
-	94,  // 94: temporal.api.cloud.cloudservice.v1.CloudService.CreateApiKey:output_type -> temporal.api.cloud.cloudservice.v1.CreateApiKeyResponse
-	95,  // 95: temporal.api.cloud.cloudservice.v1.CloudService.UpdateApiKey:output_type -> temporal.api.cloud.cloudservice.v1.UpdateApiKeyResponse
-	96,  // 96: temporal.api.cloud.cloudservice.v1.CloudService.DeleteApiKey:output_type -> temporal.api.cloud.cloudservice.v1.DeleteApiKeyResponse
-	97,  // 97: temporal.api.cloud.cloudservice.v1.CloudService.GetNexusEndpoints:output_type -> temporal.api.cloud.cloudservice.v1.GetNexusEndpointsResponse
-	98,  // 98: temporal.api.cloud.cloudservice.v1.CloudService.GetNexusEndpoint:output_type -> temporal.api.cloud.cloudservice.v1.GetNexusEndpointResponse
-	99,  // 99: temporal.api.cloud.cloudservice.v1.CloudService.CreateNexusEndpoint:output_type -> temporal.api.cloud.cloudservice.v1.CreateNexusEndpointResponse
-	100, // 100: temporal.api.cloud.cloudservice.v1.CloudService.UpdateNexusEndpoint:output_type -> temporal.api.cloud.cloudservice.v1.UpdateNexusEndpointResponse
-	101, // 101: temporal.api.cloud.cloudservice.v1.CloudService.DeleteNexusEndpoint:output_type -> temporal.api.cloud.cloudservice.v1.DeleteNexusEndpointResponse
-	102, // 102: temporal.api.cloud.cloudservice.v1.CloudService.GetUserGroups:output_type -> temporal.api.cloud.cloudservice.v1.GetUserGroupsResponse
-	103, // 103: temporal.api.cloud.cloudservice.v1.CloudService.GetUserGroup:output_type -> temporal.api.cloud.cloudservice.v1.GetUserGroupResponse
-	104, // 104: temporal.api.cloud.cloudservice.v1.CloudService.CreateUserGroup:output_type -> temporal.api.cloud.cloudservice.v1.CreateUserGroupResponse
-	105, // 105: temporal.api.cloud.cloudservice.v1.CloudService.UpdateUserGroup:output_type -> temporal.api.cloud.cloudservice.v1.UpdateUserGroupResponse
-	106, // 106: temporal.api.cloud.cloudservice.v1.CloudService.DeleteUserGroup:output_type -> temporal.api.cloud.cloudservice.v1.DeleteUserGroupResponse
-	107, // 107: temporal.api.cloud.cloudservice.v1.CloudService.SetUserGroupNamespaceAccess:output_type -> temporal.api.cloud.cloudservice.v1.SetUserGroupNamespaceAccessResponse
-	108, // 108: temporal.api.cloud.cloudservice.v1.CloudService.AddUserGroupMember:output_type -> temporal.api.cloud.cloudservice.v1.AddUserGroupMemberResponse
-	109, // 109: temporal.api.cloud.cloudservice.v1.CloudService.RemoveUserGroupMember:output_type -> temporal.api.cloud.cloudservice.v1.RemoveUserGroupMemberResponse
-	110, // 110: temporal.api.cloud.cloudservice.v1.CloudService.GetUserGroupMembers:output_type -> temporal.api.cloud.cloudservice.v1.GetUserGroupMembersResponse
-	111, // 111: temporal.api.cloud.cloudservice.v1.CloudService.CreateServiceAccount:output_type -> temporal.api.cloud.cloudservice.v1.CreateServiceAccountResponse
-	112, // 112: temporal.api.cloud.cloudservice.v1.CloudService.GetServiceAccount:output_type -> temporal.api.cloud.cloudservice.v1.GetServiceAccountResponse
-	113, // 113: temporal.api.cloud.cloudservice.v1.CloudService.GetServiceAccounts:output_type -> temporal.api.cloud.cloudservice.v1.GetServiceAccountsResponse
-	114, // 114: temporal.api.cloud.cloudservice.v1.CloudService.UpdateServiceAccount:output_type -> temporal.api.cloud.cloudservice.v1.UpdateServiceAccountResponse
-	115, // 115: temporal.api.cloud.cloudservice.v1.CloudService.SetServiceAccountNamespaceAccess:output_type -> temporal.api.cloud.cloudservice.v1.SetServiceAccountNamespaceAccessResponse
-	116, // 116: temporal.api.cloud.cloudservice.v1.CloudService.DeleteServiceAccount:output_type -> temporal.api.cloud.cloudservice.v1.DeleteServiceAccountResponse
-	117, // 117: temporal.api.cloud.cloudservice.v1.CloudService.GetUsage:output_type -> temporal.api.cloud.cloudservice.v1.GetUsageResponse
-	118, // 118: temporal.api.cloud.cloudservice.v1.CloudService.GetAccount:output_type -> temporal.api.cloud.cloudservice.v1.GetAccountResponse
-	119, // 119: temporal.api.cloud.cloudservice.v1.CloudService.UpdateAccount:output_type -> temporal.api.cloud.cloudservice.v1.UpdateAccountResponse
-	120, // 120: temporal.api.cloud.cloudservice.v1.CloudService.CreateNamespaceExportSink:output_type -> temporal.api.cloud.cloudservice.v1.CreateNamespaceExportSinkResponse
-	121, // 121: temporal.api.cloud.cloudservice.v1.CloudService.GetNamespaceExportSink:output_type -> temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinkResponse
-	122, // 122: temporal.api.cloud.cloudservice.v1.CloudService.GetNamespaceExportSinks:output_type -> temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinksResponse
-	123, // 123: temporal.api.cloud.cloudservice.v1.CloudService.UpdateNamespaceExportSink:output_type -> temporal.api.cloud.cloudservice.v1.UpdateNamespaceExportSinkResponse
-	124, // 124: temporal.api.cloud.cloudservice.v1.CloudService.DeleteNamespaceExportSink:output_type -> temporal.api.cloud.cloudservice.v1.DeleteNamespaceExportSinkResponse
-	125, // 125: temporal.api.cloud.cloudservice.v1.CloudService.ValidateNamespaceExportSink:output_type -> temporal.api.cloud.cloudservice.v1.ValidateNamespaceExportSinkResponse
-	126, // 126: temporal.api.cloud.cloudservice.v1.CloudService.UpdateNamespaceTags:output_type -> temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsResponse
-	127, // 127: temporal.api.cloud.cloudservice.v1.CloudService.CreateConnectivityRule:output_type -> temporal.api.cloud.cloudservice.v1.CreateConnectivityRuleResponse
-	128, // 128: temporal.api.cloud.cloudservice.v1.CloudService.GetConnectivityRule:output_type -> temporal.api.cloud.cloudservice.v1.GetConnectivityRuleResponse
-	129, // 129: temporal.api.cloud.cloudservice.v1.CloudService.GetConnectivityRules:output_type -> temporal.api.cloud.cloudservice.v1.GetConnectivityRulesResponse
-	130, // 130: temporal.api.cloud.cloudservice.v1.CloudService.DeleteConnectivityRule:output_type -> temporal.api.cloud.cloudservice.v1.DeleteConnectivityRuleResponse
-	131, // 131: temporal.api.cloud.cloudservice.v1.CloudService.GetAuditLogs:output_type -> temporal.api.cloud.cloudservice.v1.GetAuditLogsResponse
-	132, // 132: temporal.api.cloud.cloudservice.v1.CloudService.ValidateAccountAuditLogSink:output_type -> temporal.api.cloud.cloudservice.v1.ValidateAccountAuditLogSinkResponse
-	133, // 133: temporal.api.cloud.cloudservice.v1.CloudService.CreateAccountAuditLogSink:output_type -> temporal.api.cloud.cloudservice.v1.CreateAccountAuditLogSinkResponse
-	134, // 134: temporal.api.cloud.cloudservice.v1.CloudService.GetAccountAuditLogSink:output_type -> temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinkResponse
-	135, // 135: temporal.api.cloud.cloudservice.v1.CloudService.GetAccountAuditLogSinks:output_type -> temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinksResponse
-	136, // 136: temporal.api.cloud.cloudservice.v1.CloudService.UpdateAccountAuditLogSink:output_type -> temporal.api.cloud.cloudservice.v1.UpdateAccountAuditLogSinkResponse
-	137, // 137: temporal.api.cloud.cloudservice.v1.CloudService.DeleteAccountAuditLogSink:output_type -> temporal.api.cloud.cloudservice.v1.DeleteAccountAuditLogSinkResponse
-	138, // 138: temporal.api.cloud.cloudservice.v1.CloudService.GetNamespaceCapacityInfo:output_type -> temporal.api.cloud.cloudservice.v1.GetNamespaceCapacityInfoResponse
-	139, // 139: temporal.api.cloud.cloudservice.v1.CloudService.CreateBillingReport:output_type -> temporal.api.cloud.cloudservice.v1.CreateBillingReportResponse
-	140, // 140: temporal.api.cloud.cloudservice.v1.CloudService.GetBillingReport:output_type -> temporal.api.cloud.cloudservice.v1.GetBillingReportResponse
-	141, // 141: temporal.api.cloud.cloudservice.v1.CloudService.GetCustomRoles:output_type -> temporal.api.cloud.cloudservice.v1.GetCustomRolesResponse
-	142, // 142: temporal.api.cloud.cloudservice.v1.CloudService.GetCustomRole:output_type -> temporal.api.cloud.cloudservice.v1.GetCustomRoleResponse
-	143, // 143: temporal.api.cloud.cloudservice.v1.CloudService.CreateCustomRole:output_type -> temporal.api.cloud.cloudservice.v1.CreateCustomRoleResponse
-	144, // 144: temporal.api.cloud.cloudservice.v1.CloudService.UpdateCustomRole:output_type -> temporal.api.cloud.cloudservice.v1.UpdateCustomRoleResponse
-	145, // 145: temporal.api.cloud.cloudservice.v1.CloudService.DeleteCustomRole:output_type -> temporal.api.cloud.cloudservice.v1.DeleteCustomRoleResponse
-	73,  // [73:146] is the sub-list for method output_type
-	0,   // [0:73] is the sub-list for method input_type
+	73,  // 73: temporal.api.cloud.cloudservice.v1.CloudService.GetUserNamespaceAssignments:input_type -> temporal.api.cloud.cloudservice.v1.GetUserNamespaceAssignmentsRequest
+	74,  // 74: temporal.api.cloud.cloudservice.v1.CloudService.GetServiceAccountNamespaceAssignments:input_type -> temporal.api.cloud.cloudservice.v1.GetServiceAccountNamespaceAssignmentsRequest
+	75,  // 75: temporal.api.cloud.cloudservice.v1.CloudService.GetUserGroupNamespaceAssignments:input_type -> temporal.api.cloud.cloudservice.v1.GetUserGroupNamespaceAssignmentsRequest
+	76,  // 76: temporal.api.cloud.cloudservice.v1.CloudService.GetCurrentIdentity:output_type -> temporal.api.cloud.cloudservice.v1.GetCurrentIdentityResponse
+	77,  // 77: temporal.api.cloud.cloudservice.v1.CloudService.GetUsers:output_type -> temporal.api.cloud.cloudservice.v1.GetUsersResponse
+	78,  // 78: temporal.api.cloud.cloudservice.v1.CloudService.GetUser:output_type -> temporal.api.cloud.cloudservice.v1.GetUserResponse
+	79,  // 79: temporal.api.cloud.cloudservice.v1.CloudService.CreateUser:output_type -> temporal.api.cloud.cloudservice.v1.CreateUserResponse
+	80,  // 80: temporal.api.cloud.cloudservice.v1.CloudService.UpdateUser:output_type -> temporal.api.cloud.cloudservice.v1.UpdateUserResponse
+	81,  // 81: temporal.api.cloud.cloudservice.v1.CloudService.DeleteUser:output_type -> temporal.api.cloud.cloudservice.v1.DeleteUserResponse
+	82,  // 82: temporal.api.cloud.cloudservice.v1.CloudService.SetUserNamespaceAccess:output_type -> temporal.api.cloud.cloudservice.v1.SetUserNamespaceAccessResponse
+	83,  // 83: temporal.api.cloud.cloudservice.v1.CloudService.GetAsyncOperation:output_type -> temporal.api.cloud.cloudservice.v1.GetAsyncOperationResponse
+	84,  // 84: temporal.api.cloud.cloudservice.v1.CloudService.CreateNamespace:output_type -> temporal.api.cloud.cloudservice.v1.CreateNamespaceResponse
+	85,  // 85: temporal.api.cloud.cloudservice.v1.CloudService.GetNamespaces:output_type -> temporal.api.cloud.cloudservice.v1.GetNamespacesResponse
+	86,  // 86: temporal.api.cloud.cloudservice.v1.CloudService.GetNamespace:output_type -> temporal.api.cloud.cloudservice.v1.GetNamespaceResponse
+	87,  // 87: temporal.api.cloud.cloudservice.v1.CloudService.UpdateNamespace:output_type -> temporal.api.cloud.cloudservice.v1.UpdateNamespaceResponse
+	88,  // 88: temporal.api.cloud.cloudservice.v1.CloudService.RenameCustomSearchAttribute:output_type -> temporal.api.cloud.cloudservice.v1.RenameCustomSearchAttributeResponse
+	89,  // 89: temporal.api.cloud.cloudservice.v1.CloudService.DeleteNamespace:output_type -> temporal.api.cloud.cloudservice.v1.DeleteNamespaceResponse
+	90,  // 90: temporal.api.cloud.cloudservice.v1.CloudService.FailoverNamespaceRegion:output_type -> temporal.api.cloud.cloudservice.v1.FailoverNamespaceRegionResponse
+	91,  // 91: temporal.api.cloud.cloudservice.v1.CloudService.AddNamespaceRegion:output_type -> temporal.api.cloud.cloudservice.v1.AddNamespaceRegionResponse
+	92,  // 92: temporal.api.cloud.cloudservice.v1.CloudService.DeleteNamespaceRegion:output_type -> temporal.api.cloud.cloudservice.v1.DeleteNamespaceRegionResponse
+	93,  // 93: temporal.api.cloud.cloudservice.v1.CloudService.GetRegions:output_type -> temporal.api.cloud.cloudservice.v1.GetRegionsResponse
+	94,  // 94: temporal.api.cloud.cloudservice.v1.CloudService.GetRegion:output_type -> temporal.api.cloud.cloudservice.v1.GetRegionResponse
+	95,  // 95: temporal.api.cloud.cloudservice.v1.CloudService.GetApiKeys:output_type -> temporal.api.cloud.cloudservice.v1.GetApiKeysResponse
+	96,  // 96: temporal.api.cloud.cloudservice.v1.CloudService.GetApiKey:output_type -> temporal.api.cloud.cloudservice.v1.GetApiKeyResponse
+	97,  // 97: temporal.api.cloud.cloudservice.v1.CloudService.CreateApiKey:output_type -> temporal.api.cloud.cloudservice.v1.CreateApiKeyResponse
+	98,  // 98: temporal.api.cloud.cloudservice.v1.CloudService.UpdateApiKey:output_type -> temporal.api.cloud.cloudservice.v1.UpdateApiKeyResponse
+	99,  // 99: temporal.api.cloud.cloudservice.v1.CloudService.DeleteApiKey:output_type -> temporal.api.cloud.cloudservice.v1.DeleteApiKeyResponse
+	100, // 100: temporal.api.cloud.cloudservice.v1.CloudService.GetNexusEndpoints:output_type -> temporal.api.cloud.cloudservice.v1.GetNexusEndpointsResponse
+	101, // 101: temporal.api.cloud.cloudservice.v1.CloudService.GetNexusEndpoint:output_type -> temporal.api.cloud.cloudservice.v1.GetNexusEndpointResponse
+	102, // 102: temporal.api.cloud.cloudservice.v1.CloudService.CreateNexusEndpoint:output_type -> temporal.api.cloud.cloudservice.v1.CreateNexusEndpointResponse
+	103, // 103: temporal.api.cloud.cloudservice.v1.CloudService.UpdateNexusEndpoint:output_type -> temporal.api.cloud.cloudservice.v1.UpdateNexusEndpointResponse
+	104, // 104: temporal.api.cloud.cloudservice.v1.CloudService.DeleteNexusEndpoint:output_type -> temporal.api.cloud.cloudservice.v1.DeleteNexusEndpointResponse
+	105, // 105: temporal.api.cloud.cloudservice.v1.CloudService.GetUserGroups:output_type -> temporal.api.cloud.cloudservice.v1.GetUserGroupsResponse
+	106, // 106: temporal.api.cloud.cloudservice.v1.CloudService.GetUserGroup:output_type -> temporal.api.cloud.cloudservice.v1.GetUserGroupResponse
+	107, // 107: temporal.api.cloud.cloudservice.v1.CloudService.CreateUserGroup:output_type -> temporal.api.cloud.cloudservice.v1.CreateUserGroupResponse
+	108, // 108: temporal.api.cloud.cloudservice.v1.CloudService.UpdateUserGroup:output_type -> temporal.api.cloud.cloudservice.v1.UpdateUserGroupResponse
+	109, // 109: temporal.api.cloud.cloudservice.v1.CloudService.DeleteUserGroup:output_type -> temporal.api.cloud.cloudservice.v1.DeleteUserGroupResponse
+	110, // 110: temporal.api.cloud.cloudservice.v1.CloudService.SetUserGroupNamespaceAccess:output_type -> temporal.api.cloud.cloudservice.v1.SetUserGroupNamespaceAccessResponse
+	111, // 111: temporal.api.cloud.cloudservice.v1.CloudService.AddUserGroupMember:output_type -> temporal.api.cloud.cloudservice.v1.AddUserGroupMemberResponse
+	112, // 112: temporal.api.cloud.cloudservice.v1.CloudService.RemoveUserGroupMember:output_type -> temporal.api.cloud.cloudservice.v1.RemoveUserGroupMemberResponse
+	113, // 113: temporal.api.cloud.cloudservice.v1.CloudService.GetUserGroupMembers:output_type -> temporal.api.cloud.cloudservice.v1.GetUserGroupMembersResponse
+	114, // 114: temporal.api.cloud.cloudservice.v1.CloudService.CreateServiceAccount:output_type -> temporal.api.cloud.cloudservice.v1.CreateServiceAccountResponse
+	115, // 115: temporal.api.cloud.cloudservice.v1.CloudService.GetServiceAccount:output_type -> temporal.api.cloud.cloudservice.v1.GetServiceAccountResponse
+	116, // 116: temporal.api.cloud.cloudservice.v1.CloudService.GetServiceAccounts:output_type -> temporal.api.cloud.cloudservice.v1.GetServiceAccountsResponse
+	117, // 117: temporal.api.cloud.cloudservice.v1.CloudService.UpdateServiceAccount:output_type -> temporal.api.cloud.cloudservice.v1.UpdateServiceAccountResponse
+	118, // 118: temporal.api.cloud.cloudservice.v1.CloudService.SetServiceAccountNamespaceAccess:output_type -> temporal.api.cloud.cloudservice.v1.SetServiceAccountNamespaceAccessResponse
+	119, // 119: temporal.api.cloud.cloudservice.v1.CloudService.DeleteServiceAccount:output_type -> temporal.api.cloud.cloudservice.v1.DeleteServiceAccountResponse
+	120, // 120: temporal.api.cloud.cloudservice.v1.CloudService.GetUsage:output_type -> temporal.api.cloud.cloudservice.v1.GetUsageResponse
+	121, // 121: temporal.api.cloud.cloudservice.v1.CloudService.GetAccount:output_type -> temporal.api.cloud.cloudservice.v1.GetAccountResponse
+	122, // 122: temporal.api.cloud.cloudservice.v1.CloudService.UpdateAccount:output_type -> temporal.api.cloud.cloudservice.v1.UpdateAccountResponse
+	123, // 123: temporal.api.cloud.cloudservice.v1.CloudService.CreateNamespaceExportSink:output_type -> temporal.api.cloud.cloudservice.v1.CreateNamespaceExportSinkResponse
+	124, // 124: temporal.api.cloud.cloudservice.v1.CloudService.GetNamespaceExportSink:output_type -> temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinkResponse
+	125, // 125: temporal.api.cloud.cloudservice.v1.CloudService.GetNamespaceExportSinks:output_type -> temporal.api.cloud.cloudservice.v1.GetNamespaceExportSinksResponse
+	126, // 126: temporal.api.cloud.cloudservice.v1.CloudService.UpdateNamespaceExportSink:output_type -> temporal.api.cloud.cloudservice.v1.UpdateNamespaceExportSinkResponse
+	127, // 127: temporal.api.cloud.cloudservice.v1.CloudService.DeleteNamespaceExportSink:output_type -> temporal.api.cloud.cloudservice.v1.DeleteNamespaceExportSinkResponse
+	128, // 128: temporal.api.cloud.cloudservice.v1.CloudService.ValidateNamespaceExportSink:output_type -> temporal.api.cloud.cloudservice.v1.ValidateNamespaceExportSinkResponse
+	129, // 129: temporal.api.cloud.cloudservice.v1.CloudService.UpdateNamespaceTags:output_type -> temporal.api.cloud.cloudservice.v1.UpdateNamespaceTagsResponse
+	130, // 130: temporal.api.cloud.cloudservice.v1.CloudService.CreateConnectivityRule:output_type -> temporal.api.cloud.cloudservice.v1.CreateConnectivityRuleResponse
+	131, // 131: temporal.api.cloud.cloudservice.v1.CloudService.GetConnectivityRule:output_type -> temporal.api.cloud.cloudservice.v1.GetConnectivityRuleResponse
+	132, // 132: temporal.api.cloud.cloudservice.v1.CloudService.GetConnectivityRules:output_type -> temporal.api.cloud.cloudservice.v1.GetConnectivityRulesResponse
+	133, // 133: temporal.api.cloud.cloudservice.v1.CloudService.DeleteConnectivityRule:output_type -> temporal.api.cloud.cloudservice.v1.DeleteConnectivityRuleResponse
+	134, // 134: temporal.api.cloud.cloudservice.v1.CloudService.GetAuditLogs:output_type -> temporal.api.cloud.cloudservice.v1.GetAuditLogsResponse
+	135, // 135: temporal.api.cloud.cloudservice.v1.CloudService.ValidateAccountAuditLogSink:output_type -> temporal.api.cloud.cloudservice.v1.ValidateAccountAuditLogSinkResponse
+	136, // 136: temporal.api.cloud.cloudservice.v1.CloudService.CreateAccountAuditLogSink:output_type -> temporal.api.cloud.cloudservice.v1.CreateAccountAuditLogSinkResponse
+	137, // 137: temporal.api.cloud.cloudservice.v1.CloudService.GetAccountAuditLogSink:output_type -> temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinkResponse
+	138, // 138: temporal.api.cloud.cloudservice.v1.CloudService.GetAccountAuditLogSinks:output_type -> temporal.api.cloud.cloudservice.v1.GetAccountAuditLogSinksResponse
+	139, // 139: temporal.api.cloud.cloudservice.v1.CloudService.UpdateAccountAuditLogSink:output_type -> temporal.api.cloud.cloudservice.v1.UpdateAccountAuditLogSinkResponse
+	140, // 140: temporal.api.cloud.cloudservice.v1.CloudService.DeleteAccountAuditLogSink:output_type -> temporal.api.cloud.cloudservice.v1.DeleteAccountAuditLogSinkResponse
+	141, // 141: temporal.api.cloud.cloudservice.v1.CloudService.GetNamespaceCapacityInfo:output_type -> temporal.api.cloud.cloudservice.v1.GetNamespaceCapacityInfoResponse
+	142, // 142: temporal.api.cloud.cloudservice.v1.CloudService.CreateBillingReport:output_type -> temporal.api.cloud.cloudservice.v1.CreateBillingReportResponse
+	143, // 143: temporal.api.cloud.cloudservice.v1.CloudService.GetBillingReport:output_type -> temporal.api.cloud.cloudservice.v1.GetBillingReportResponse
+	144, // 144: temporal.api.cloud.cloudservice.v1.CloudService.GetCustomRoles:output_type -> temporal.api.cloud.cloudservice.v1.GetCustomRolesResponse
+	145, // 145: temporal.api.cloud.cloudservice.v1.CloudService.GetCustomRole:output_type -> temporal.api.cloud.cloudservice.v1.GetCustomRoleResponse
+	146, // 146: temporal.api.cloud.cloudservice.v1.CloudService.CreateCustomRole:output_type -> temporal.api.cloud.cloudservice.v1.CreateCustomRoleResponse
+	147, // 147: temporal.api.cloud.cloudservice.v1.CloudService.UpdateCustomRole:output_type -> temporal.api.cloud.cloudservice.v1.UpdateCustomRoleResponse
+	148, // 148: temporal.api.cloud.cloudservice.v1.CloudService.DeleteCustomRole:output_type -> temporal.api.cloud.cloudservice.v1.DeleteCustomRoleResponse
+	149, // 149: temporal.api.cloud.cloudservice.v1.CloudService.GetUserNamespaceAssignments:output_type -> temporal.api.cloud.cloudservice.v1.GetUserNamespaceAssignmentsResponse
+	150, // 150: temporal.api.cloud.cloudservice.v1.CloudService.GetServiceAccountNamespaceAssignments:output_type -> temporal.api.cloud.cloudservice.v1.GetServiceAccountNamespaceAssignmentsResponse
+	151, // 151: temporal.api.cloud.cloudservice.v1.CloudService.GetUserGroupNamespaceAssignments:output_type -> temporal.api.cloud.cloudservice.v1.GetUserGroupNamespaceAssignmentsResponse
+	76,  // [76:152] is the sub-list for method output_type
+	0,   // [0:76] is the sub-list for method input_type
 	0,   // [0:0] is the sub-list for extension type_name
 	0,   // [0:0] is the sub-list for extension extendee
 	0,   // [0:0] is the sub-list for field type_name

--- a/api/cloudservice/v1/service_grpc.pb.go
+++ b/api/cloudservice/v1/service_grpc.pb.go
@@ -19,79 +19,82 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	CloudService_GetCurrentIdentity_FullMethodName               = "/temporal.api.cloud.cloudservice.v1.CloudService/GetCurrentIdentity"
-	CloudService_GetUsers_FullMethodName                         = "/temporal.api.cloud.cloudservice.v1.CloudService/GetUsers"
-	CloudService_GetUser_FullMethodName                          = "/temporal.api.cloud.cloudservice.v1.CloudService/GetUser"
-	CloudService_CreateUser_FullMethodName                       = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateUser"
-	CloudService_UpdateUser_FullMethodName                       = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateUser"
-	CloudService_DeleteUser_FullMethodName                       = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteUser"
-	CloudService_SetUserNamespaceAccess_FullMethodName           = "/temporal.api.cloud.cloudservice.v1.CloudService/SetUserNamespaceAccess"
-	CloudService_GetAsyncOperation_FullMethodName                = "/temporal.api.cloud.cloudservice.v1.CloudService/GetAsyncOperation"
-	CloudService_CreateNamespace_FullMethodName                  = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateNamespace"
-	CloudService_GetNamespaces_FullMethodName                    = "/temporal.api.cloud.cloudservice.v1.CloudService/GetNamespaces"
-	CloudService_GetNamespace_FullMethodName                     = "/temporal.api.cloud.cloudservice.v1.CloudService/GetNamespace"
-	CloudService_UpdateNamespace_FullMethodName                  = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateNamespace"
-	CloudService_RenameCustomSearchAttribute_FullMethodName      = "/temporal.api.cloud.cloudservice.v1.CloudService/RenameCustomSearchAttribute"
-	CloudService_DeleteNamespace_FullMethodName                  = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteNamespace"
-	CloudService_FailoverNamespaceRegion_FullMethodName          = "/temporal.api.cloud.cloudservice.v1.CloudService/FailoverNamespaceRegion"
-	CloudService_AddNamespaceRegion_FullMethodName               = "/temporal.api.cloud.cloudservice.v1.CloudService/AddNamespaceRegion"
-	CloudService_DeleteNamespaceRegion_FullMethodName            = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteNamespaceRegion"
-	CloudService_GetRegions_FullMethodName                       = "/temporal.api.cloud.cloudservice.v1.CloudService/GetRegions"
-	CloudService_GetRegion_FullMethodName                        = "/temporal.api.cloud.cloudservice.v1.CloudService/GetRegion"
-	CloudService_GetApiKeys_FullMethodName                       = "/temporal.api.cloud.cloudservice.v1.CloudService/GetApiKeys"
-	CloudService_GetApiKey_FullMethodName                        = "/temporal.api.cloud.cloudservice.v1.CloudService/GetApiKey"
-	CloudService_CreateApiKey_FullMethodName                     = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateApiKey"
-	CloudService_UpdateApiKey_FullMethodName                     = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateApiKey"
-	CloudService_DeleteApiKey_FullMethodName                     = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteApiKey"
-	CloudService_GetNexusEndpoints_FullMethodName                = "/temporal.api.cloud.cloudservice.v1.CloudService/GetNexusEndpoints"
-	CloudService_GetNexusEndpoint_FullMethodName                 = "/temporal.api.cloud.cloudservice.v1.CloudService/GetNexusEndpoint"
-	CloudService_CreateNexusEndpoint_FullMethodName              = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateNexusEndpoint"
-	CloudService_UpdateNexusEndpoint_FullMethodName              = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateNexusEndpoint"
-	CloudService_DeleteNexusEndpoint_FullMethodName              = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteNexusEndpoint"
-	CloudService_GetUserGroups_FullMethodName                    = "/temporal.api.cloud.cloudservice.v1.CloudService/GetUserGroups"
-	CloudService_GetUserGroup_FullMethodName                     = "/temporal.api.cloud.cloudservice.v1.CloudService/GetUserGroup"
-	CloudService_CreateUserGroup_FullMethodName                  = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateUserGroup"
-	CloudService_UpdateUserGroup_FullMethodName                  = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateUserGroup"
-	CloudService_DeleteUserGroup_FullMethodName                  = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteUserGroup"
-	CloudService_SetUserGroupNamespaceAccess_FullMethodName      = "/temporal.api.cloud.cloudservice.v1.CloudService/SetUserGroupNamespaceAccess"
-	CloudService_AddUserGroupMember_FullMethodName               = "/temporal.api.cloud.cloudservice.v1.CloudService/AddUserGroupMember"
-	CloudService_RemoveUserGroupMember_FullMethodName            = "/temporal.api.cloud.cloudservice.v1.CloudService/RemoveUserGroupMember"
-	CloudService_GetUserGroupMembers_FullMethodName              = "/temporal.api.cloud.cloudservice.v1.CloudService/GetUserGroupMembers"
-	CloudService_CreateServiceAccount_FullMethodName             = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateServiceAccount"
-	CloudService_GetServiceAccount_FullMethodName                = "/temporal.api.cloud.cloudservice.v1.CloudService/GetServiceAccount"
-	CloudService_GetServiceAccounts_FullMethodName               = "/temporal.api.cloud.cloudservice.v1.CloudService/GetServiceAccounts"
-	CloudService_UpdateServiceAccount_FullMethodName             = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateServiceAccount"
-	CloudService_SetServiceAccountNamespaceAccess_FullMethodName = "/temporal.api.cloud.cloudservice.v1.CloudService/SetServiceAccountNamespaceAccess"
-	CloudService_DeleteServiceAccount_FullMethodName             = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteServiceAccount"
-	CloudService_GetUsage_FullMethodName                         = "/temporal.api.cloud.cloudservice.v1.CloudService/GetUsage"
-	CloudService_GetAccount_FullMethodName                       = "/temporal.api.cloud.cloudservice.v1.CloudService/GetAccount"
-	CloudService_UpdateAccount_FullMethodName                    = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateAccount"
-	CloudService_CreateNamespaceExportSink_FullMethodName        = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateNamespaceExportSink"
-	CloudService_GetNamespaceExportSink_FullMethodName           = "/temporal.api.cloud.cloudservice.v1.CloudService/GetNamespaceExportSink"
-	CloudService_GetNamespaceExportSinks_FullMethodName          = "/temporal.api.cloud.cloudservice.v1.CloudService/GetNamespaceExportSinks"
-	CloudService_UpdateNamespaceExportSink_FullMethodName        = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateNamespaceExportSink"
-	CloudService_DeleteNamespaceExportSink_FullMethodName        = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteNamespaceExportSink"
-	CloudService_ValidateNamespaceExportSink_FullMethodName      = "/temporal.api.cloud.cloudservice.v1.CloudService/ValidateNamespaceExportSink"
-	CloudService_UpdateNamespaceTags_FullMethodName              = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateNamespaceTags"
-	CloudService_CreateConnectivityRule_FullMethodName           = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateConnectivityRule"
-	CloudService_GetConnectivityRule_FullMethodName              = "/temporal.api.cloud.cloudservice.v1.CloudService/GetConnectivityRule"
-	CloudService_GetConnectivityRules_FullMethodName             = "/temporal.api.cloud.cloudservice.v1.CloudService/GetConnectivityRules"
-	CloudService_DeleteConnectivityRule_FullMethodName           = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteConnectivityRule"
-	CloudService_GetAuditLogs_FullMethodName                     = "/temporal.api.cloud.cloudservice.v1.CloudService/GetAuditLogs"
-	CloudService_ValidateAccountAuditLogSink_FullMethodName      = "/temporal.api.cloud.cloudservice.v1.CloudService/ValidateAccountAuditLogSink"
-	CloudService_CreateAccountAuditLogSink_FullMethodName        = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateAccountAuditLogSink"
-	CloudService_GetAccountAuditLogSink_FullMethodName           = "/temporal.api.cloud.cloudservice.v1.CloudService/GetAccountAuditLogSink"
-	CloudService_GetAccountAuditLogSinks_FullMethodName          = "/temporal.api.cloud.cloudservice.v1.CloudService/GetAccountAuditLogSinks"
-	CloudService_UpdateAccountAuditLogSink_FullMethodName        = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateAccountAuditLogSink"
-	CloudService_DeleteAccountAuditLogSink_FullMethodName        = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteAccountAuditLogSink"
-	CloudService_GetNamespaceCapacityInfo_FullMethodName         = "/temporal.api.cloud.cloudservice.v1.CloudService/GetNamespaceCapacityInfo"
-	CloudService_CreateBillingReport_FullMethodName              = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateBillingReport"
-	CloudService_GetBillingReport_FullMethodName                 = "/temporal.api.cloud.cloudservice.v1.CloudService/GetBillingReport"
-	CloudService_GetCustomRoles_FullMethodName                   = "/temporal.api.cloud.cloudservice.v1.CloudService/GetCustomRoles"
-	CloudService_GetCustomRole_FullMethodName                    = "/temporal.api.cloud.cloudservice.v1.CloudService/GetCustomRole"
-	CloudService_CreateCustomRole_FullMethodName                 = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateCustomRole"
-	CloudService_UpdateCustomRole_FullMethodName                 = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateCustomRole"
-	CloudService_DeleteCustomRole_FullMethodName                 = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteCustomRole"
+	CloudService_GetCurrentIdentity_FullMethodName                    = "/temporal.api.cloud.cloudservice.v1.CloudService/GetCurrentIdentity"
+	CloudService_GetUsers_FullMethodName                              = "/temporal.api.cloud.cloudservice.v1.CloudService/GetUsers"
+	CloudService_GetUser_FullMethodName                               = "/temporal.api.cloud.cloudservice.v1.CloudService/GetUser"
+	CloudService_CreateUser_FullMethodName                            = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateUser"
+	CloudService_UpdateUser_FullMethodName                            = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateUser"
+	CloudService_DeleteUser_FullMethodName                            = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteUser"
+	CloudService_SetUserNamespaceAccess_FullMethodName                = "/temporal.api.cloud.cloudservice.v1.CloudService/SetUserNamespaceAccess"
+	CloudService_GetAsyncOperation_FullMethodName                     = "/temporal.api.cloud.cloudservice.v1.CloudService/GetAsyncOperation"
+	CloudService_CreateNamespace_FullMethodName                       = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateNamespace"
+	CloudService_GetNamespaces_FullMethodName                         = "/temporal.api.cloud.cloudservice.v1.CloudService/GetNamespaces"
+	CloudService_GetNamespace_FullMethodName                          = "/temporal.api.cloud.cloudservice.v1.CloudService/GetNamespace"
+	CloudService_UpdateNamespace_FullMethodName                       = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateNamespace"
+	CloudService_RenameCustomSearchAttribute_FullMethodName           = "/temporal.api.cloud.cloudservice.v1.CloudService/RenameCustomSearchAttribute"
+	CloudService_DeleteNamespace_FullMethodName                       = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteNamespace"
+	CloudService_FailoverNamespaceRegion_FullMethodName               = "/temporal.api.cloud.cloudservice.v1.CloudService/FailoverNamespaceRegion"
+	CloudService_AddNamespaceRegion_FullMethodName                    = "/temporal.api.cloud.cloudservice.v1.CloudService/AddNamespaceRegion"
+	CloudService_DeleteNamespaceRegion_FullMethodName                 = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteNamespaceRegion"
+	CloudService_GetRegions_FullMethodName                            = "/temporal.api.cloud.cloudservice.v1.CloudService/GetRegions"
+	CloudService_GetRegion_FullMethodName                             = "/temporal.api.cloud.cloudservice.v1.CloudService/GetRegion"
+	CloudService_GetApiKeys_FullMethodName                            = "/temporal.api.cloud.cloudservice.v1.CloudService/GetApiKeys"
+	CloudService_GetApiKey_FullMethodName                             = "/temporal.api.cloud.cloudservice.v1.CloudService/GetApiKey"
+	CloudService_CreateApiKey_FullMethodName                          = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateApiKey"
+	CloudService_UpdateApiKey_FullMethodName                          = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateApiKey"
+	CloudService_DeleteApiKey_FullMethodName                          = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteApiKey"
+	CloudService_GetNexusEndpoints_FullMethodName                     = "/temporal.api.cloud.cloudservice.v1.CloudService/GetNexusEndpoints"
+	CloudService_GetNexusEndpoint_FullMethodName                      = "/temporal.api.cloud.cloudservice.v1.CloudService/GetNexusEndpoint"
+	CloudService_CreateNexusEndpoint_FullMethodName                   = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateNexusEndpoint"
+	CloudService_UpdateNexusEndpoint_FullMethodName                   = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateNexusEndpoint"
+	CloudService_DeleteNexusEndpoint_FullMethodName                   = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteNexusEndpoint"
+	CloudService_GetUserGroups_FullMethodName                         = "/temporal.api.cloud.cloudservice.v1.CloudService/GetUserGroups"
+	CloudService_GetUserGroup_FullMethodName                          = "/temporal.api.cloud.cloudservice.v1.CloudService/GetUserGroup"
+	CloudService_CreateUserGroup_FullMethodName                       = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateUserGroup"
+	CloudService_UpdateUserGroup_FullMethodName                       = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateUserGroup"
+	CloudService_DeleteUserGroup_FullMethodName                       = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteUserGroup"
+	CloudService_SetUserGroupNamespaceAccess_FullMethodName           = "/temporal.api.cloud.cloudservice.v1.CloudService/SetUserGroupNamespaceAccess"
+	CloudService_AddUserGroupMember_FullMethodName                    = "/temporal.api.cloud.cloudservice.v1.CloudService/AddUserGroupMember"
+	CloudService_RemoveUserGroupMember_FullMethodName                 = "/temporal.api.cloud.cloudservice.v1.CloudService/RemoveUserGroupMember"
+	CloudService_GetUserGroupMembers_FullMethodName                   = "/temporal.api.cloud.cloudservice.v1.CloudService/GetUserGroupMembers"
+	CloudService_CreateServiceAccount_FullMethodName                  = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateServiceAccount"
+	CloudService_GetServiceAccount_FullMethodName                     = "/temporal.api.cloud.cloudservice.v1.CloudService/GetServiceAccount"
+	CloudService_GetServiceAccounts_FullMethodName                    = "/temporal.api.cloud.cloudservice.v1.CloudService/GetServiceAccounts"
+	CloudService_UpdateServiceAccount_FullMethodName                  = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateServiceAccount"
+	CloudService_SetServiceAccountNamespaceAccess_FullMethodName      = "/temporal.api.cloud.cloudservice.v1.CloudService/SetServiceAccountNamespaceAccess"
+	CloudService_DeleteServiceAccount_FullMethodName                  = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteServiceAccount"
+	CloudService_GetUsage_FullMethodName                              = "/temporal.api.cloud.cloudservice.v1.CloudService/GetUsage"
+	CloudService_GetAccount_FullMethodName                            = "/temporal.api.cloud.cloudservice.v1.CloudService/GetAccount"
+	CloudService_UpdateAccount_FullMethodName                         = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateAccount"
+	CloudService_CreateNamespaceExportSink_FullMethodName             = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateNamespaceExportSink"
+	CloudService_GetNamespaceExportSink_FullMethodName                = "/temporal.api.cloud.cloudservice.v1.CloudService/GetNamespaceExportSink"
+	CloudService_GetNamespaceExportSinks_FullMethodName               = "/temporal.api.cloud.cloudservice.v1.CloudService/GetNamespaceExportSinks"
+	CloudService_UpdateNamespaceExportSink_FullMethodName             = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateNamespaceExportSink"
+	CloudService_DeleteNamespaceExportSink_FullMethodName             = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteNamespaceExportSink"
+	CloudService_ValidateNamespaceExportSink_FullMethodName           = "/temporal.api.cloud.cloudservice.v1.CloudService/ValidateNamespaceExportSink"
+	CloudService_UpdateNamespaceTags_FullMethodName                   = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateNamespaceTags"
+	CloudService_CreateConnectivityRule_FullMethodName                = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateConnectivityRule"
+	CloudService_GetConnectivityRule_FullMethodName                   = "/temporal.api.cloud.cloudservice.v1.CloudService/GetConnectivityRule"
+	CloudService_GetConnectivityRules_FullMethodName                  = "/temporal.api.cloud.cloudservice.v1.CloudService/GetConnectivityRules"
+	CloudService_DeleteConnectivityRule_FullMethodName                = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteConnectivityRule"
+	CloudService_GetAuditLogs_FullMethodName                          = "/temporal.api.cloud.cloudservice.v1.CloudService/GetAuditLogs"
+	CloudService_ValidateAccountAuditLogSink_FullMethodName           = "/temporal.api.cloud.cloudservice.v1.CloudService/ValidateAccountAuditLogSink"
+	CloudService_CreateAccountAuditLogSink_FullMethodName             = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateAccountAuditLogSink"
+	CloudService_GetAccountAuditLogSink_FullMethodName                = "/temporal.api.cloud.cloudservice.v1.CloudService/GetAccountAuditLogSink"
+	CloudService_GetAccountAuditLogSinks_FullMethodName               = "/temporal.api.cloud.cloudservice.v1.CloudService/GetAccountAuditLogSinks"
+	CloudService_UpdateAccountAuditLogSink_FullMethodName             = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateAccountAuditLogSink"
+	CloudService_DeleteAccountAuditLogSink_FullMethodName             = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteAccountAuditLogSink"
+	CloudService_GetNamespaceCapacityInfo_FullMethodName              = "/temporal.api.cloud.cloudservice.v1.CloudService/GetNamespaceCapacityInfo"
+	CloudService_CreateBillingReport_FullMethodName                   = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateBillingReport"
+	CloudService_GetBillingReport_FullMethodName                      = "/temporal.api.cloud.cloudservice.v1.CloudService/GetBillingReport"
+	CloudService_GetCustomRoles_FullMethodName                        = "/temporal.api.cloud.cloudservice.v1.CloudService/GetCustomRoles"
+	CloudService_GetCustomRole_FullMethodName                         = "/temporal.api.cloud.cloudservice.v1.CloudService/GetCustomRole"
+	CloudService_CreateCustomRole_FullMethodName                      = "/temporal.api.cloud.cloudservice.v1.CloudService/CreateCustomRole"
+	CloudService_UpdateCustomRole_FullMethodName                      = "/temporal.api.cloud.cloudservice.v1.CloudService/UpdateCustomRole"
+	CloudService_DeleteCustomRole_FullMethodName                      = "/temporal.api.cloud.cloudservice.v1.CloudService/DeleteCustomRole"
+	CloudService_GetUserNamespaceAssignments_FullMethodName           = "/temporal.api.cloud.cloudservice.v1.CloudService/GetUserNamespaceAssignments"
+	CloudService_GetServiceAccountNamespaceAssignments_FullMethodName = "/temporal.api.cloud.cloudservice.v1.CloudService/GetServiceAccountNamespaceAssignments"
+	CloudService_GetUserGroupNamespaceAssignments_FullMethodName      = "/temporal.api.cloud.cloudservice.v1.CloudService/GetUserGroupNamespaceAssignments"
 )
 
 // CloudServiceClient is the client API for CloudService service.
@@ -253,6 +256,12 @@ type CloudServiceClient interface {
 	UpdateCustomRole(ctx context.Context, in *UpdateCustomRoleRequest, opts ...grpc.CallOption) (*UpdateCustomRoleResponse, error)
 	// Delete a custom role
 	DeleteCustomRole(ctx context.Context, in *DeleteCustomRoleRequest, opts ...grpc.CallOption) (*DeleteCustomRoleResponse, error)
+	// Get users with access to a namespace
+	GetUserNamespaceAssignments(ctx context.Context, in *GetUserNamespaceAssignmentsRequest, opts ...grpc.CallOption) (*GetUserNamespaceAssignmentsResponse, error)
+	// Get service accounts with access to a namespace
+	GetServiceAccountNamespaceAssignments(ctx context.Context, in *GetServiceAccountNamespaceAssignmentsRequest, opts ...grpc.CallOption) (*GetServiceAccountNamespaceAssignmentsResponse, error)
+	// Get user groups with access to a namespace
+	GetUserGroupNamespaceAssignments(ctx context.Context, in *GetUserGroupNamespaceAssignmentsRequest, opts ...grpc.CallOption) (*GetUserGroupNamespaceAssignmentsResponse, error)
 }
 
 type cloudServiceClient struct {
@@ -995,6 +1004,36 @@ func (c *cloudServiceClient) DeleteCustomRole(ctx context.Context, in *DeleteCus
 	return out, nil
 }
 
+func (c *cloudServiceClient) GetUserNamespaceAssignments(ctx context.Context, in *GetUserNamespaceAssignmentsRequest, opts ...grpc.CallOption) (*GetUserNamespaceAssignmentsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetUserNamespaceAssignmentsResponse)
+	err := c.cc.Invoke(ctx, CloudService_GetUserNamespaceAssignments_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *cloudServiceClient) GetServiceAccountNamespaceAssignments(ctx context.Context, in *GetServiceAccountNamespaceAssignmentsRequest, opts ...grpc.CallOption) (*GetServiceAccountNamespaceAssignmentsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetServiceAccountNamespaceAssignmentsResponse)
+	err := c.cc.Invoke(ctx, CloudService_GetServiceAccountNamespaceAssignments_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *cloudServiceClient) GetUserGroupNamespaceAssignments(ctx context.Context, in *GetUserGroupNamespaceAssignmentsRequest, opts ...grpc.CallOption) (*GetUserGroupNamespaceAssignmentsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetUserGroupNamespaceAssignmentsResponse)
+	err := c.cc.Invoke(ctx, CloudService_GetUserGroupNamespaceAssignments_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // CloudServiceServer is the server API for CloudService service.
 // All implementations must embed UnimplementedCloudServiceServer
 // for forward compatibility.
@@ -1154,6 +1193,12 @@ type CloudServiceServer interface {
 	UpdateCustomRole(context.Context, *UpdateCustomRoleRequest) (*UpdateCustomRoleResponse, error)
 	// Delete a custom role
 	DeleteCustomRole(context.Context, *DeleteCustomRoleRequest) (*DeleteCustomRoleResponse, error)
+	// Get users with access to a namespace
+	GetUserNamespaceAssignments(context.Context, *GetUserNamespaceAssignmentsRequest) (*GetUserNamespaceAssignmentsResponse, error)
+	// Get service accounts with access to a namespace
+	GetServiceAccountNamespaceAssignments(context.Context, *GetServiceAccountNamespaceAssignmentsRequest) (*GetServiceAccountNamespaceAssignmentsResponse, error)
+	// Get user groups with access to a namespace
+	GetUserGroupNamespaceAssignments(context.Context, *GetUserGroupNamespaceAssignmentsRequest) (*GetUserGroupNamespaceAssignmentsResponse, error)
 	mustEmbedUnimplementedCloudServiceServer()
 }
 
@@ -1382,6 +1427,15 @@ func (UnimplementedCloudServiceServer) UpdateCustomRole(context.Context, *Update
 }
 func (UnimplementedCloudServiceServer) DeleteCustomRole(context.Context, *DeleteCustomRoleRequest) (*DeleteCustomRoleResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteCustomRole not implemented")
+}
+func (UnimplementedCloudServiceServer) GetUserNamespaceAssignments(context.Context, *GetUserNamespaceAssignmentsRequest) (*GetUserNamespaceAssignmentsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetUserNamespaceAssignments not implemented")
+}
+func (UnimplementedCloudServiceServer) GetServiceAccountNamespaceAssignments(context.Context, *GetServiceAccountNamespaceAssignmentsRequest) (*GetServiceAccountNamespaceAssignmentsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetServiceAccountNamespaceAssignments not implemented")
+}
+func (UnimplementedCloudServiceServer) GetUserGroupNamespaceAssignments(context.Context, *GetUserGroupNamespaceAssignmentsRequest) (*GetUserGroupNamespaceAssignmentsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetUserGroupNamespaceAssignments not implemented")
 }
 func (UnimplementedCloudServiceServer) mustEmbedUnimplementedCloudServiceServer() {}
 func (UnimplementedCloudServiceServer) testEmbeddedByValue()                      {}
@@ -2718,6 +2772,60 @@ func _CloudService_DeleteCustomRole_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _CloudService_GetUserNamespaceAssignments_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetUserNamespaceAssignmentsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CloudServiceServer).GetUserNamespaceAssignments(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CloudService_GetUserNamespaceAssignments_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CloudServiceServer).GetUserNamespaceAssignments(ctx, req.(*GetUserNamespaceAssignmentsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _CloudService_GetServiceAccountNamespaceAssignments_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetServiceAccountNamespaceAssignmentsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CloudServiceServer).GetServiceAccountNamespaceAssignments(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CloudService_GetServiceAccountNamespaceAssignments_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CloudServiceServer).GetServiceAccountNamespaceAssignments(ctx, req.(*GetServiceAccountNamespaceAssignmentsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _CloudService_GetUserGroupNamespaceAssignments_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetUserGroupNamespaceAssignmentsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CloudServiceServer).GetUserGroupNamespaceAssignments(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CloudService_GetUserGroupNamespaceAssignments_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CloudServiceServer).GetUserGroupNamespaceAssignments(ctx, req.(*GetUserGroupNamespaceAssignmentsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // CloudService_ServiceDesc is the grpc.ServiceDesc for CloudService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -3016,6 +3124,18 @@ var CloudService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteCustomRole",
 			Handler:    _CloudService_DeleteCustomRole_Handler,
+		},
+		{
+			MethodName: "GetUserNamespaceAssignments",
+			Handler:    _CloudService_GetUserNamespaceAssignments_Handler,
+		},
+		{
+			MethodName: "GetServiceAccountNamespaceAssignments",
+			Handler:    _CloudService_GetServiceAccountNamespaceAssignments_Handler,
+		},
+		{
+			MethodName: "GetUserGroupNamespaceAssignments",
+			Handler:    _CloudService_GetUserGroupNamespaceAssignments_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/identity/v1/message.pb.go
+++ b/api/identity/v1/message.pb.go
@@ -1763,6 +1763,249 @@ func (x *CustomRole) GetLastModifiedTime() *timestamppb.Timestamp {
 	return nil
 }
 
+type UserNamespaceAssignment struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The ID of the user.
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// The email of the user.
+	Email string `protobuf:"bytes,2,opt,name=email,proto3" json:"email,omitempty"`
+	// The access assigned to the user at the namespace level.
+	NamespaceAccess *NamespaceAccess `protobuf:"bytes,3,opt,name=namespace_access,json=namespaceAccess,proto3" json:"namespace_access,omitempty"`
+	// True if the user has inherited access to the namespace through an account or project role.
+	InheritedAccess bool `protobuf:"varint,4,opt,name=inherited_access,json=inheritedAccess,proto3" json:"inherited_access,omitempty"`
+	// The current resource version of the user.
+	ResourceVersion string `protobuf:"bytes,5,opt,name=resource_version,json=resourceVersion,proto3" json:"resource_version,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *UserNamespaceAssignment) Reset() {
+	*x = UserNamespaceAssignment{}
+	mi := &file_temporal_api_cloud_identity_v1_message_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserNamespaceAssignment) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserNamespaceAssignment) ProtoMessage() {}
+
+func (x *UserNamespaceAssignment) ProtoReflect() protoreflect.Message {
+	mi := &file_temporal_api_cloud_identity_v1_message_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserNamespaceAssignment.ProtoReflect.Descriptor instead.
+func (*UserNamespaceAssignment) Descriptor() ([]byte, []int) {
+	return file_temporal_api_cloud_identity_v1_message_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *UserNamespaceAssignment) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *UserNamespaceAssignment) GetEmail() string {
+	if x != nil {
+		return x.Email
+	}
+	return ""
+}
+
+func (x *UserNamespaceAssignment) GetNamespaceAccess() *NamespaceAccess {
+	if x != nil {
+		return x.NamespaceAccess
+	}
+	return nil
+}
+
+func (x *UserNamespaceAssignment) GetInheritedAccess() bool {
+	if x != nil {
+		return x.InheritedAccess
+	}
+	return false
+}
+
+func (x *UserNamespaceAssignment) GetResourceVersion() string {
+	if x != nil {
+		return x.ResourceVersion
+	}
+	return ""
+}
+
+type ServiceAccountNamespaceAssignment struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The ID of the service account.
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// The name of the service account.
+	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// The access assigned to the service account at the namespace level.
+	NamespaceAccess *NamespaceAccess `protobuf:"bytes,3,opt,name=namespace_access,json=namespaceAccess,proto3" json:"namespace_access,omitempty"`
+	// True if the service account has inherited access to the namespace through an account or project role.
+	InheritedAccess bool `protobuf:"varint,4,opt,name=inherited_access,json=inheritedAccess,proto3" json:"inherited_access,omitempty"`
+	// The current resource version of the service account.
+	ResourceVersion string `protobuf:"bytes,5,opt,name=resource_version,json=resourceVersion,proto3" json:"resource_version,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ServiceAccountNamespaceAssignment) Reset() {
+	*x = ServiceAccountNamespaceAssignment{}
+	mi := &file_temporal_api_cloud_identity_v1_message_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ServiceAccountNamespaceAssignment) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ServiceAccountNamespaceAssignment) ProtoMessage() {}
+
+func (x *ServiceAccountNamespaceAssignment) ProtoReflect() protoreflect.Message {
+	mi := &file_temporal_api_cloud_identity_v1_message_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ServiceAccountNamespaceAssignment.ProtoReflect.Descriptor instead.
+func (*ServiceAccountNamespaceAssignment) Descriptor() ([]byte, []int) {
+	return file_temporal_api_cloud_identity_v1_message_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *ServiceAccountNamespaceAssignment) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ServiceAccountNamespaceAssignment) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ServiceAccountNamespaceAssignment) GetNamespaceAccess() *NamespaceAccess {
+	if x != nil {
+		return x.NamespaceAccess
+	}
+	return nil
+}
+
+func (x *ServiceAccountNamespaceAssignment) GetInheritedAccess() bool {
+	if x != nil {
+		return x.InheritedAccess
+	}
+	return false
+}
+
+func (x *ServiceAccountNamespaceAssignment) GetResourceVersion() string {
+	if x != nil {
+		return x.ResourceVersion
+	}
+	return ""
+}
+
+type UserGroupNamespaceAssignment struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The ID of the group.
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// The display name of the group.
+	DisplayName string `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	// The access assigned to the group at the namespace level.
+	NamespaceAccess *NamespaceAccess `protobuf:"bytes,3,opt,name=namespace_access,json=namespaceAccess,proto3" json:"namespace_access,omitempty"`
+	// True if the group has inherited access to the namespace through an account or project role.
+	InheritedAccess bool `protobuf:"varint,4,opt,name=inherited_access,json=inheritedAccess,proto3" json:"inherited_access,omitempty"`
+	// The current resource version of the group.
+	ResourceVersion string `protobuf:"bytes,5,opt,name=resource_version,json=resourceVersion,proto3" json:"resource_version,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *UserGroupNamespaceAssignment) Reset() {
+	*x = UserGroupNamespaceAssignment{}
+	mi := &file_temporal_api_cloud_identity_v1_message_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserGroupNamespaceAssignment) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserGroupNamespaceAssignment) ProtoMessage() {}
+
+func (x *UserGroupNamespaceAssignment) ProtoReflect() protoreflect.Message {
+	mi := &file_temporal_api_cloud_identity_v1_message_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserGroupNamespaceAssignment.ProtoReflect.Descriptor instead.
+func (*UserGroupNamespaceAssignment) Descriptor() ([]byte, []int) {
+	return file_temporal_api_cloud_identity_v1_message_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *UserGroupNamespaceAssignment) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *UserGroupNamespaceAssignment) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *UserGroupNamespaceAssignment) GetNamespaceAccess() *NamespaceAccess {
+	if x != nil {
+		return x.NamespaceAccess
+	}
+	return nil
+}
+
+func (x *UserGroupNamespaceAssignment) GetInheritedAccess() bool {
+	if x != nil {
+		return x.InheritedAccess
+	}
+	return false
+}
+
+func (x *UserGroupNamespaceAssignment) GetResourceVersion() string {
+	if x != nil {
+		return x.ResourceVersion
+	}
+	return ""
+}
+
 type CustomRoleSpec_Resources struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The resource type the permission applies to.
@@ -1777,7 +2020,7 @@ type CustomRoleSpec_Resources struct {
 
 func (x *CustomRoleSpec_Resources) Reset() {
 	*x = CustomRoleSpec_Resources{}
-	mi := &file_temporal_api_cloud_identity_v1_message_proto_msgTypes[21]
+	mi := &file_temporal_api_cloud_identity_v1_message_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1789,7 +2032,7 @@ func (x *CustomRoleSpec_Resources) String() string {
 func (*CustomRoleSpec_Resources) ProtoMessage() {}
 
 func (x *CustomRoleSpec_Resources) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_api_cloud_identity_v1_message_proto_msgTypes[21]
+	mi := &file_temporal_api_cloud_identity_v1_message_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1838,7 +2081,7 @@ type CustomRoleSpec_Permission struct {
 
 func (x *CustomRoleSpec_Permission) Reset() {
 	*x = CustomRoleSpec_Permission{}
-	mi := &file_temporal_api_cloud_identity_v1_message_proto_msgTypes[22]
+	mi := &file_temporal_api_cloud_identity_v1_message_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1850,7 +2093,7 @@ func (x *CustomRoleSpec_Permission) String() string {
 func (*CustomRoleSpec_Permission) ProtoMessage() {}
 
 func (x *CustomRoleSpec_Permission) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_api_cloud_identity_v1_message_proto_msgTypes[22]
+	mi := &file_temporal_api_cloud_identity_v1_message_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2222,24 +2465,72 @@ var file_temporal_api_cloud_identity_v1_message_proto_rawDesc = string([]byte{
 	0x69, 0x6d, 0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
 	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x54, 0x69, 0x6d, 0x65,
 	0x73, 0x74, 0x61, 0x6d, 0x70, 0x52, 0x10, 0x6c, 0x61, 0x73, 0x74, 0x4d, 0x6f, 0x64, 0x69, 0x66,
-	0x69, 0x65, 0x64, 0x54, 0x69, 0x6d, 0x65, 0x2a, 0x5c, 0x0a, 0x09, 0x4f, 0x77, 0x6e, 0x65, 0x72,
-	0x54, 0x79, 0x70, 0x65, 0x12, 0x1a, 0x0a, 0x16, 0x4f, 0x57, 0x4e, 0x45, 0x52, 0x5f, 0x54, 0x59,
-	0x50, 0x45, 0x5f, 0x55, 0x4e, 0x53, 0x50, 0x45, 0x43, 0x49, 0x46, 0x49, 0x45, 0x44, 0x10, 0x00,
-	0x12, 0x13, 0x0a, 0x0f, 0x4f, 0x57, 0x4e, 0x45, 0x52, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55,
-	0x53, 0x45, 0x52, 0x10, 0x01, 0x12, 0x1e, 0x0a, 0x1a, 0x4f, 0x57, 0x4e, 0x45, 0x52, 0x5f, 0x54,
-	0x59, 0x50, 0x45, 0x5f, 0x53, 0x45, 0x52, 0x56, 0x49, 0x43, 0x45, 0x5f, 0x41, 0x43, 0x43, 0x4f,
-	0x55, 0x4e, 0x54, 0x10, 0x02, 0x42, 0xac, 0x01, 0x0a, 0x21, 0x69, 0x6f, 0x2e, 0x74, 0x65, 0x6d,
-	0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2e,
-	0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x2e, 0x76, 0x31, 0x42, 0x0c, 0x4d, 0x65, 0x73,
-	0x73, 0x61, 0x67, 0x65, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x2d, 0x67, 0x6f, 0x2e,
-	0x74, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x69, 0x6f, 0x2f, 0x61, 0x70, 0x69, 0x2f,
-	0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2f, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x2f, 0x76,
-	0x31, 0x3b, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0xaa, 0x02, 0x20, 0x54, 0x65, 0x6d,
-	0x70, 0x6f, 0x72, 0x61, 0x6c, 0x69, 0x6f, 0x2e, 0x41, 0x70, 0x69, 0x2e, 0x43, 0x6c, 0x6f, 0x75,
-	0x64, 0x2e, 0x49, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x2e, 0x56, 0x31, 0xea, 0x02, 0x24,
-	0x54, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x69, 0x6f, 0x3a, 0x3a, 0x41, 0x70, 0x69, 0x3a,
-	0x3a, 0x43, 0x6c, 0x6f, 0x75, 0x64, 0x3a, 0x3a, 0x49, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79,
-	0x3a, 0x3a, 0x56, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x69, 0x65, 0x64, 0x54, 0x69, 0x6d, 0x65, 0x22, 0xf1, 0x01, 0x0a, 0x17, 0x55, 0x73, 0x65, 0x72,
+	0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x73, 0x73, 0x69, 0x67, 0x6e, 0x6d,
+	0x65, 0x6e, 0x74, 0x12, 0x0e, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x02, 0x69, 0x64, 0x12, 0x14, 0x0a, 0x05, 0x65, 0x6d, 0x61, 0x69, 0x6c, 0x18, 0x02, 0x20, 0x01,
+	0x28, 0x09, 0x52, 0x05, 0x65, 0x6d, 0x61, 0x69, 0x6c, 0x12, 0x5a, 0x0a, 0x10, 0x6e, 0x61, 0x6d,
+	0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x5f, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x18, 0x03, 0x20,
+	0x01, 0x28, 0x0b, 0x32, 0x2f, 0x2e, 0x74, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x61,
+	0x70, 0x69, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2e, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74,
+	0x79, 0x2e, 0x76, 0x31, 0x2e, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x63,
+	0x63, 0x65, 0x73, 0x73, 0x52, 0x0f, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41,
+	0x63, 0x63, 0x65, 0x73, 0x73, 0x12, 0x29, 0x0a, 0x10, 0x69, 0x6e, 0x68, 0x65, 0x72, 0x69, 0x74,
+	0x65, 0x64, 0x5f, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x08, 0x52,
+	0x0f, 0x69, 0x6e, 0x68, 0x65, 0x72, 0x69, 0x74, 0x65, 0x64, 0x41, 0x63, 0x63, 0x65, 0x73, 0x73,
+	0x12, 0x29, 0x0a, 0x10, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x5f, 0x76, 0x65, 0x72,
+	0x73, 0x69, 0x6f, 0x6e, 0x18, 0x05, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x72, 0x65, 0x73, 0x6f,
+	0x75, 0x72, 0x63, 0x65, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x22, 0xf9, 0x01, 0x0a, 0x21,
+	0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x4e, 0x61,
+	0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x73, 0x73, 0x69, 0x67, 0x6e, 0x6d, 0x65, 0x6e,
+	0x74, 0x12, 0x0e, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x02, 0x69,
+	0x64, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x5a, 0x0a, 0x10, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61,
+	0x63, 0x65, 0x5f, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32,
+	0x2f, 0x2e, 0x74, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x63,
+	0x6c, 0x6f, 0x75, 0x64, 0x2e, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x2e, 0x76, 0x31,
+	0x2e, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x63, 0x63, 0x65, 0x73, 0x73,
+	0x52, 0x0f, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x63, 0x63, 0x65, 0x73,
+	0x73, 0x12, 0x29, 0x0a, 0x10, 0x69, 0x6e, 0x68, 0x65, 0x72, 0x69, 0x74, 0x65, 0x64, 0x5f, 0x61,
+	0x63, 0x63, 0x65, 0x73, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0f, 0x69, 0x6e, 0x68,
+	0x65, 0x72, 0x69, 0x74, 0x65, 0x64, 0x41, 0x63, 0x63, 0x65, 0x73, 0x73, 0x12, 0x29, 0x0a, 0x10,
+	0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x5f, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e,
+	0x18, 0x05, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65,
+	0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x22, 0x83, 0x02, 0x0a, 0x1c, 0x55, 0x73, 0x65, 0x72,
+	0x47, 0x72, 0x6f, 0x75, 0x70, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x41, 0x73,
+	0x73, 0x69, 0x67, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x12, 0x0e, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x02, 0x69, 0x64, 0x12, 0x21, 0x0a, 0x0c, 0x64, 0x69, 0x73, 0x70,
+	0x6c, 0x61, 0x79, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0b,
+	0x64, 0x69, 0x73, 0x70, 0x6c, 0x61, 0x79, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x5a, 0x0a, 0x10, 0x6e,
+	0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x5f, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x18,
+	0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2f, 0x2e, 0x74, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c,
+	0x2e, 0x61, 0x70, 0x69, 0x2e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2e, 0x69, 0x64, 0x65, 0x6e, 0x74,
+	0x69, 0x74, 0x79, 0x2e, 0x76, 0x31, 0x2e, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65,
+	0x41, 0x63, 0x63, 0x65, 0x73, 0x73, 0x52, 0x0f, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63,
+	0x65, 0x41, 0x63, 0x63, 0x65, 0x73, 0x73, 0x12, 0x29, 0x0a, 0x10, 0x69, 0x6e, 0x68, 0x65, 0x72,
+	0x69, 0x74, 0x65, 0x64, 0x5f, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28,
+	0x08, 0x52, 0x0f, 0x69, 0x6e, 0x68, 0x65, 0x72, 0x69, 0x74, 0x65, 0x64, 0x41, 0x63, 0x63, 0x65,
+	0x73, 0x73, 0x12, 0x29, 0x0a, 0x10, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x5f, 0x76,
+	0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x05, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x72, 0x65,
+	0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x2a, 0x5c, 0x0a,
+	0x09, 0x4f, 0x77, 0x6e, 0x65, 0x72, 0x54, 0x79, 0x70, 0x65, 0x12, 0x1a, 0x0a, 0x16, 0x4f, 0x57,
+	0x4e, 0x45, 0x52, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x4e, 0x53, 0x50, 0x45, 0x43, 0x49,
+	0x46, 0x49, 0x45, 0x44, 0x10, 0x00, 0x12, 0x13, 0x0a, 0x0f, 0x4f, 0x57, 0x4e, 0x45, 0x52, 0x5f,
+	0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x53, 0x45, 0x52, 0x10, 0x01, 0x12, 0x1e, 0x0a, 0x1a, 0x4f,
+	0x57, 0x4e, 0x45, 0x52, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x45, 0x52, 0x56, 0x49, 0x43,
+	0x45, 0x5f, 0x41, 0x43, 0x43, 0x4f, 0x55, 0x4e, 0x54, 0x10, 0x02, 0x42, 0xac, 0x01, 0x0a, 0x21,
+	0x69, 0x6f, 0x2e, 0x74, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x61, 0x70, 0x69, 0x2e,
+	0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2e, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x2e, 0x76,
+	0x31, 0x42, 0x0c, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50,
+	0x01, 0x5a, 0x2d, 0x67, 0x6f, 0x2e, 0x74, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x2e, 0x69,
+	0x6f, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2f, 0x69, 0x64, 0x65, 0x6e,
+	0x74, 0x69, 0x74, 0x79, 0x2f, 0x76, 0x31, 0x3b, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79,
+	0xaa, 0x02, 0x20, 0x54, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x69, 0x6f, 0x2e, 0x41, 0x70,
+	0x69, 0x2e, 0x43, 0x6c, 0x6f, 0x75, 0x64, 0x2e, 0x49, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79,
+	0x2e, 0x56, 0x31, 0xea, 0x02, 0x24, 0x54, 0x65, 0x6d, 0x70, 0x6f, 0x72, 0x61, 0x6c, 0x69, 0x6f,
+	0x3a, 0x3a, 0x41, 0x70, 0x69, 0x3a, 0x3a, 0x43, 0x6c, 0x6f, 0x75, 0x64, 0x3a, 0x3a, 0x49, 0x64,
+	0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x3a, 0x3a, 0x56, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74,
+	0x6f, 0x33,
 })
 
 var (
@@ -2255,85 +2546,91 @@ func file_temporal_api_cloud_identity_v1_message_proto_rawDescGZIP() []byte {
 }
 
 var file_temporal_api_cloud_identity_v1_message_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_temporal_api_cloud_identity_v1_message_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
+var file_temporal_api_cloud_identity_v1_message_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_temporal_api_cloud_identity_v1_message_proto_goTypes = []any{
-	(OwnerType)(0),                    // 0: temporal.api.cloud.identity.v1.OwnerType
-	(AccountAccess_Role)(0),           // 1: temporal.api.cloud.identity.v1.AccountAccess.Role
-	(NamespaceAccess_Permission)(0),   // 2: temporal.api.cloud.identity.v1.NamespaceAccess.Permission
-	(*AccountAccess)(nil),             // 3: temporal.api.cloud.identity.v1.AccountAccess
-	(*NamespaceAccess)(nil),           // 4: temporal.api.cloud.identity.v1.NamespaceAccess
-	(*Access)(nil),                    // 5: temporal.api.cloud.identity.v1.Access
-	(*NamespaceScopedAccess)(nil),     // 6: temporal.api.cloud.identity.v1.NamespaceScopedAccess
-	(*UserSpec)(nil),                  // 7: temporal.api.cloud.identity.v1.UserSpec
-	(*Invitation)(nil),                // 8: temporal.api.cloud.identity.v1.Invitation
-	(*User)(nil),                      // 9: temporal.api.cloud.identity.v1.User
-	(*GoogleGroupSpec)(nil),           // 10: temporal.api.cloud.identity.v1.GoogleGroupSpec
-	(*SCIMGroupSpec)(nil),             // 11: temporal.api.cloud.identity.v1.SCIMGroupSpec
-	(*CloudGroupSpec)(nil),            // 12: temporal.api.cloud.identity.v1.CloudGroupSpec
-	(*UserGroupSpec)(nil),             // 13: temporal.api.cloud.identity.v1.UserGroupSpec
-	(*UserGroup)(nil),                 // 14: temporal.api.cloud.identity.v1.UserGroup
-	(*UserGroupMemberId)(nil),         // 15: temporal.api.cloud.identity.v1.UserGroupMemberId
-	(*UserGroupMember)(nil),           // 16: temporal.api.cloud.identity.v1.UserGroupMember
-	(*ServiceAccount)(nil),            // 17: temporal.api.cloud.identity.v1.ServiceAccount
-	(*ServiceAccountSpec)(nil),        // 18: temporal.api.cloud.identity.v1.ServiceAccountSpec
-	(*ApiKey)(nil),                    // 19: temporal.api.cloud.identity.v1.ApiKey
-	(*ApiKeySpec)(nil),                // 20: temporal.api.cloud.identity.v1.ApiKeySpec
-	(*CustomRoleSpec)(nil),            // 21: temporal.api.cloud.identity.v1.CustomRoleSpec
-	(*CustomRole)(nil),                // 22: temporal.api.cloud.identity.v1.CustomRole
-	nil,                               // 23: temporal.api.cloud.identity.v1.Access.NamespaceAccessesEntry
-	(*CustomRoleSpec_Resources)(nil),  // 24: temporal.api.cloud.identity.v1.CustomRoleSpec.Resources
-	(*CustomRoleSpec_Permission)(nil), // 25: temporal.api.cloud.identity.v1.CustomRoleSpec.Permission
-	(*timestamppb.Timestamp)(nil),     // 26: google.protobuf.Timestamp
-	(v1.ResourceState)(0),             // 27: temporal.api.cloud.resource.v1.ResourceState
+	(OwnerType)(0),                            // 0: temporal.api.cloud.identity.v1.OwnerType
+	(AccountAccess_Role)(0),                   // 1: temporal.api.cloud.identity.v1.AccountAccess.Role
+	(NamespaceAccess_Permission)(0),           // 2: temporal.api.cloud.identity.v1.NamespaceAccess.Permission
+	(*AccountAccess)(nil),                     // 3: temporal.api.cloud.identity.v1.AccountAccess
+	(*NamespaceAccess)(nil),                   // 4: temporal.api.cloud.identity.v1.NamespaceAccess
+	(*Access)(nil),                            // 5: temporal.api.cloud.identity.v1.Access
+	(*NamespaceScopedAccess)(nil),             // 6: temporal.api.cloud.identity.v1.NamespaceScopedAccess
+	(*UserSpec)(nil),                          // 7: temporal.api.cloud.identity.v1.UserSpec
+	(*Invitation)(nil),                        // 8: temporal.api.cloud.identity.v1.Invitation
+	(*User)(nil),                              // 9: temporal.api.cloud.identity.v1.User
+	(*GoogleGroupSpec)(nil),                   // 10: temporal.api.cloud.identity.v1.GoogleGroupSpec
+	(*SCIMGroupSpec)(nil),                     // 11: temporal.api.cloud.identity.v1.SCIMGroupSpec
+	(*CloudGroupSpec)(nil),                    // 12: temporal.api.cloud.identity.v1.CloudGroupSpec
+	(*UserGroupSpec)(nil),                     // 13: temporal.api.cloud.identity.v1.UserGroupSpec
+	(*UserGroup)(nil),                         // 14: temporal.api.cloud.identity.v1.UserGroup
+	(*UserGroupMemberId)(nil),                 // 15: temporal.api.cloud.identity.v1.UserGroupMemberId
+	(*UserGroupMember)(nil),                   // 16: temporal.api.cloud.identity.v1.UserGroupMember
+	(*ServiceAccount)(nil),                    // 17: temporal.api.cloud.identity.v1.ServiceAccount
+	(*ServiceAccountSpec)(nil),                // 18: temporal.api.cloud.identity.v1.ServiceAccountSpec
+	(*ApiKey)(nil),                            // 19: temporal.api.cloud.identity.v1.ApiKey
+	(*ApiKeySpec)(nil),                        // 20: temporal.api.cloud.identity.v1.ApiKeySpec
+	(*CustomRoleSpec)(nil),                    // 21: temporal.api.cloud.identity.v1.CustomRoleSpec
+	(*CustomRole)(nil),                        // 22: temporal.api.cloud.identity.v1.CustomRole
+	(*UserNamespaceAssignment)(nil),           // 23: temporal.api.cloud.identity.v1.UserNamespaceAssignment
+	(*ServiceAccountNamespaceAssignment)(nil), // 24: temporal.api.cloud.identity.v1.ServiceAccountNamespaceAssignment
+	(*UserGroupNamespaceAssignment)(nil),      // 25: temporal.api.cloud.identity.v1.UserGroupNamespaceAssignment
+	nil,                                       // 26: temporal.api.cloud.identity.v1.Access.NamespaceAccessesEntry
+	(*CustomRoleSpec_Resources)(nil),          // 27: temporal.api.cloud.identity.v1.CustomRoleSpec.Resources
+	(*CustomRoleSpec_Permission)(nil),         // 28: temporal.api.cloud.identity.v1.CustomRoleSpec.Permission
+	(*timestamppb.Timestamp)(nil),             // 29: google.protobuf.Timestamp
+	(v1.ResourceState)(0),                     // 30: temporal.api.cloud.resource.v1.ResourceState
 }
 var file_temporal_api_cloud_identity_v1_message_proto_depIdxs = []int32{
 	1,  // 0: temporal.api.cloud.identity.v1.AccountAccess.role:type_name -> temporal.api.cloud.identity.v1.AccountAccess.Role
 	2,  // 1: temporal.api.cloud.identity.v1.NamespaceAccess.permission:type_name -> temporal.api.cloud.identity.v1.NamespaceAccess.Permission
 	3,  // 2: temporal.api.cloud.identity.v1.Access.account_access:type_name -> temporal.api.cloud.identity.v1.AccountAccess
-	23, // 3: temporal.api.cloud.identity.v1.Access.namespace_accesses:type_name -> temporal.api.cloud.identity.v1.Access.NamespaceAccessesEntry
+	26, // 3: temporal.api.cloud.identity.v1.Access.namespace_accesses:type_name -> temporal.api.cloud.identity.v1.Access.NamespaceAccessesEntry
 	4,  // 4: temporal.api.cloud.identity.v1.NamespaceScopedAccess.access:type_name -> temporal.api.cloud.identity.v1.NamespaceAccess
 	5,  // 5: temporal.api.cloud.identity.v1.UserSpec.access:type_name -> temporal.api.cloud.identity.v1.Access
-	26, // 6: temporal.api.cloud.identity.v1.Invitation.created_time:type_name -> google.protobuf.Timestamp
-	26, // 7: temporal.api.cloud.identity.v1.Invitation.expired_time:type_name -> google.protobuf.Timestamp
+	29, // 6: temporal.api.cloud.identity.v1.Invitation.created_time:type_name -> google.protobuf.Timestamp
+	29, // 7: temporal.api.cloud.identity.v1.Invitation.expired_time:type_name -> google.protobuf.Timestamp
 	7,  // 8: temporal.api.cloud.identity.v1.User.spec:type_name -> temporal.api.cloud.identity.v1.UserSpec
-	27, // 9: temporal.api.cloud.identity.v1.User.state:type_name -> temporal.api.cloud.resource.v1.ResourceState
+	30, // 9: temporal.api.cloud.identity.v1.User.state:type_name -> temporal.api.cloud.resource.v1.ResourceState
 	8,  // 10: temporal.api.cloud.identity.v1.User.invitation:type_name -> temporal.api.cloud.identity.v1.Invitation
-	26, // 11: temporal.api.cloud.identity.v1.User.created_time:type_name -> google.protobuf.Timestamp
-	26, // 12: temporal.api.cloud.identity.v1.User.last_modified_time:type_name -> google.protobuf.Timestamp
+	29, // 11: temporal.api.cloud.identity.v1.User.created_time:type_name -> google.protobuf.Timestamp
+	29, // 12: temporal.api.cloud.identity.v1.User.last_modified_time:type_name -> google.protobuf.Timestamp
 	5,  // 13: temporal.api.cloud.identity.v1.UserGroupSpec.access:type_name -> temporal.api.cloud.identity.v1.Access
 	10, // 14: temporal.api.cloud.identity.v1.UserGroupSpec.google_group:type_name -> temporal.api.cloud.identity.v1.GoogleGroupSpec
 	11, // 15: temporal.api.cloud.identity.v1.UserGroupSpec.scim_group:type_name -> temporal.api.cloud.identity.v1.SCIMGroupSpec
 	12, // 16: temporal.api.cloud.identity.v1.UserGroupSpec.cloud_group:type_name -> temporal.api.cloud.identity.v1.CloudGroupSpec
 	13, // 17: temporal.api.cloud.identity.v1.UserGroup.spec:type_name -> temporal.api.cloud.identity.v1.UserGroupSpec
-	27, // 18: temporal.api.cloud.identity.v1.UserGroup.state:type_name -> temporal.api.cloud.resource.v1.ResourceState
-	26, // 19: temporal.api.cloud.identity.v1.UserGroup.created_time:type_name -> google.protobuf.Timestamp
-	26, // 20: temporal.api.cloud.identity.v1.UserGroup.last_modified_time:type_name -> google.protobuf.Timestamp
+	30, // 18: temporal.api.cloud.identity.v1.UserGroup.state:type_name -> temporal.api.cloud.resource.v1.ResourceState
+	29, // 19: temporal.api.cloud.identity.v1.UserGroup.created_time:type_name -> google.protobuf.Timestamp
+	29, // 20: temporal.api.cloud.identity.v1.UserGroup.last_modified_time:type_name -> google.protobuf.Timestamp
 	15, // 21: temporal.api.cloud.identity.v1.UserGroupMember.member_id:type_name -> temporal.api.cloud.identity.v1.UserGroupMemberId
-	26, // 22: temporal.api.cloud.identity.v1.UserGroupMember.created_time:type_name -> google.protobuf.Timestamp
+	29, // 22: temporal.api.cloud.identity.v1.UserGroupMember.created_time:type_name -> google.protobuf.Timestamp
 	18, // 23: temporal.api.cloud.identity.v1.ServiceAccount.spec:type_name -> temporal.api.cloud.identity.v1.ServiceAccountSpec
-	27, // 24: temporal.api.cloud.identity.v1.ServiceAccount.state:type_name -> temporal.api.cloud.resource.v1.ResourceState
-	26, // 25: temporal.api.cloud.identity.v1.ServiceAccount.created_time:type_name -> google.protobuf.Timestamp
-	26, // 26: temporal.api.cloud.identity.v1.ServiceAccount.last_modified_time:type_name -> google.protobuf.Timestamp
+	30, // 24: temporal.api.cloud.identity.v1.ServiceAccount.state:type_name -> temporal.api.cloud.resource.v1.ResourceState
+	29, // 25: temporal.api.cloud.identity.v1.ServiceAccount.created_time:type_name -> google.protobuf.Timestamp
+	29, // 26: temporal.api.cloud.identity.v1.ServiceAccount.last_modified_time:type_name -> google.protobuf.Timestamp
 	5,  // 27: temporal.api.cloud.identity.v1.ServiceAccountSpec.access:type_name -> temporal.api.cloud.identity.v1.Access
 	6,  // 28: temporal.api.cloud.identity.v1.ServiceAccountSpec.namespace_scoped_access:type_name -> temporal.api.cloud.identity.v1.NamespaceScopedAccess
 	20, // 29: temporal.api.cloud.identity.v1.ApiKey.spec:type_name -> temporal.api.cloud.identity.v1.ApiKeySpec
-	27, // 30: temporal.api.cloud.identity.v1.ApiKey.state:type_name -> temporal.api.cloud.resource.v1.ResourceState
-	26, // 31: temporal.api.cloud.identity.v1.ApiKey.created_time:type_name -> google.protobuf.Timestamp
-	26, // 32: temporal.api.cloud.identity.v1.ApiKey.last_modified_time:type_name -> google.protobuf.Timestamp
+	30, // 30: temporal.api.cloud.identity.v1.ApiKey.state:type_name -> temporal.api.cloud.resource.v1.ResourceState
+	29, // 31: temporal.api.cloud.identity.v1.ApiKey.created_time:type_name -> google.protobuf.Timestamp
+	29, // 32: temporal.api.cloud.identity.v1.ApiKey.last_modified_time:type_name -> google.protobuf.Timestamp
 	0,  // 33: temporal.api.cloud.identity.v1.ApiKeySpec.owner_type:type_name -> temporal.api.cloud.identity.v1.OwnerType
-	26, // 34: temporal.api.cloud.identity.v1.ApiKeySpec.expiry_time:type_name -> google.protobuf.Timestamp
-	25, // 35: temporal.api.cloud.identity.v1.CustomRoleSpec.permissions:type_name -> temporal.api.cloud.identity.v1.CustomRoleSpec.Permission
+	29, // 34: temporal.api.cloud.identity.v1.ApiKeySpec.expiry_time:type_name -> google.protobuf.Timestamp
+	28, // 35: temporal.api.cloud.identity.v1.CustomRoleSpec.permissions:type_name -> temporal.api.cloud.identity.v1.CustomRoleSpec.Permission
 	21, // 36: temporal.api.cloud.identity.v1.CustomRole.spec:type_name -> temporal.api.cloud.identity.v1.CustomRoleSpec
-	27, // 37: temporal.api.cloud.identity.v1.CustomRole.state:type_name -> temporal.api.cloud.resource.v1.ResourceState
-	26, // 38: temporal.api.cloud.identity.v1.CustomRole.created_time:type_name -> google.protobuf.Timestamp
-	26, // 39: temporal.api.cloud.identity.v1.CustomRole.last_modified_time:type_name -> google.protobuf.Timestamp
-	4,  // 40: temporal.api.cloud.identity.v1.Access.NamespaceAccessesEntry.value:type_name -> temporal.api.cloud.identity.v1.NamespaceAccess
-	24, // 41: temporal.api.cloud.identity.v1.CustomRoleSpec.Permission.resources:type_name -> temporal.api.cloud.identity.v1.CustomRoleSpec.Resources
-	42, // [42:42] is the sub-list for method output_type
-	42, // [42:42] is the sub-list for method input_type
-	42, // [42:42] is the sub-list for extension type_name
-	42, // [42:42] is the sub-list for extension extendee
-	0,  // [0:42] is the sub-list for field type_name
+	30, // 37: temporal.api.cloud.identity.v1.CustomRole.state:type_name -> temporal.api.cloud.resource.v1.ResourceState
+	29, // 38: temporal.api.cloud.identity.v1.CustomRole.created_time:type_name -> google.protobuf.Timestamp
+	29, // 39: temporal.api.cloud.identity.v1.CustomRole.last_modified_time:type_name -> google.protobuf.Timestamp
+	4,  // 40: temporal.api.cloud.identity.v1.UserNamespaceAssignment.namespace_access:type_name -> temporal.api.cloud.identity.v1.NamespaceAccess
+	4,  // 41: temporal.api.cloud.identity.v1.ServiceAccountNamespaceAssignment.namespace_access:type_name -> temporal.api.cloud.identity.v1.NamespaceAccess
+	4,  // 42: temporal.api.cloud.identity.v1.UserGroupNamespaceAssignment.namespace_access:type_name -> temporal.api.cloud.identity.v1.NamespaceAccess
+	4,  // 43: temporal.api.cloud.identity.v1.Access.NamespaceAccessesEntry.value:type_name -> temporal.api.cloud.identity.v1.NamespaceAccess
+	27, // 44: temporal.api.cloud.identity.v1.CustomRoleSpec.Permission.resources:type_name -> temporal.api.cloud.identity.v1.CustomRoleSpec.Resources
+	45, // [45:45] is the sub-list for method output_type
+	45, // [45:45] is the sub-list for method input_type
+	45, // [45:45] is the sub-list for extension type_name
+	45, // [45:45] is the sub-list for extension extendee
+	0,  // [0:45] is the sub-list for field type_name
 }
 
 func init() { file_temporal_api_cloud_identity_v1_message_proto_init() }
@@ -2355,7 +2652,7 @@ func file_temporal_api_cloud_identity_v1_message_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_temporal_api_cloud_identity_v1_message_proto_rawDesc), len(file_temporal_api_cloud_identity_v1_message_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   23,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/cloudclient/options.go
+++ b/cloudclient/options.go
@@ -22,8 +22,8 @@ const (
 	authorizationBearer           = "Bearer"
 	temporalCloudAPIVersionHeader = "temporal-cloud-api-version"
 
-	sdkVersion        = "0.13.0"
-	defaultAPIVersion = "v0.16.0"
+	sdkVersion        = "0.14.0"
+	defaultAPIVersion = "v0.17.0"
 )
 
 func DefaultAPIVersion() string {


### PR DESCRIPTION
Bumps `cloud-api` to https://github.com/temporalio/cloud-api/releases/tag/v0.17.0.